### PR TITLE
Add `_spy` and expose typed spies for functions, getters, and setters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
 # 2.0.0
- * Suuport complete typing of spies through the `_spy` facade.
- * Allow spying and stubbing value accessors on properties with or without getter and setter.
+ * Support typing of spies through the `_spy` facade.
+ * Allow spying and stubbing value accessors on any property

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# 2.0.0
+ * Suuport complete typing of spies through the `_spy` facade.
+ * Allow spying and stubbing value accessors on properties with or without getter and setter.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ it('should pass', () => {
 
 This util is built with and for [Jasmine](https://jasmine.github.io/) test framework. Basic understanding of Jasmine is assumed.
 
-This util requires [ES6 Proxy](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) and only contains un-compiled `*.ts` files which must be compiled with a [TypeScript](https://www.typescriptlang.org/) compiler.
+This util requires [ES6 Proxy](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) and only contains `*.ts` files that must be compiled with a [TypeScript](https://www.typescriptlang.org/) compiler.
 
 
 
@@ -66,7 +66,7 @@ const realInstance: RealInterface = new RealClass();
 const mockInstance = MockFactory.create(realInstance);
 ```
 
-#### From window object
+#### From window objects
 ```TypeScript
 /* make sure you have included dom types from the TypeScript library */
 const mockWindow  = MockFactory.create(window);
@@ -85,8 +85,8 @@ const mockLocation = MockFactory.create(location);
 ```
 
 #### Invoking functions
- * All methods will have a jasmine.Spy as the initial value. The Spy cannot be overwritten and returns `undefined` by default.
- * To access protected and private functions, cast the mockInstance `as any` or using bracket notation.
+ * All methods will have a `jasmine.Spy` as the initial value. The spy cannot be overwritten and returns `undefined` by default.
+ * To access protected and private functions, cast the mockInstance `as any` or use bracket notation.
 ```TypeScript
   mockInstance.publicMethod(42); // the spy behind it is invoked with 42
 
@@ -95,22 +95,22 @@ const mockLocation = MockFactory.create(location);
 ```
 
 #### Spying/stubbing functions
- * You can change return values of functions or assert their calls by accessing them directly or throught the `_spy` facade.
- * To access a function spy, call `mockInstance._spy.functionName._func`.
+ * You can change return values of functions or assert their calls by accessing them directly or through the `_spy` facade.
+ * Access a function spy on `mockInstance._spy.functionName._func`.
  ```TypeScript
-   (mockInstance.publicMethod as jasmine.Spy).and.returnValue(42); // it works, but requires casting
-   mockInstance._spy.publicMethod._func.and.returnValue(42); // recommended!
+   mockInstance._spy.publicMethod._func.and.returnValue(42);
+   (mockInstance.publicMethod as jasmine.Spy).and.returnValue(42); // equivalent, but not recommented because it requires casting
 
-   ((mockInstance as any).privateMethod as jasmine.Spy).and.returnValue(42); // it works, but requires two castings
-   mockInstance._spy.privateMethod._func.and.returnValue(42); // recommended!
+   mockInstance._spy.privateMethod._func.and.returnValue(42);
+   ((mockInstance as any).privateMethod as jasmine.Spy).and.returnValue(42); // equivalent, but not recommented because it requires casting twice
 ```
 
 #### Accessing properties
  * All properties have `undefined` as the initial value. The value can be overwritten with anything.
- * You can read and write access to any property, even if they were readonly in the real object.
- * To read or write value on a protected or private properties, cast the mockInstance `as any` or using bracket notation.
+ * You have read and write access to any property, even if they were readonly in the real object.
+ * To read or write value on a protected or private properties, cast the mockInstance `as any` or use bracket notation.
  * To write value on a readonly property, cast the mockInstance `as any`. Note that bracket notation won't work.
- * By default, modification to the properties will be preserved, even if a getter or setter was used in the real object.
+ * By default, modification to the properties will be preserved, even if a getter or setter exists in the real object.
 ```TypeScript
   mockInstance.publicProperty = 42;
   let temp = mockInstance.publicProperty; // temp = 42;
@@ -125,10 +125,10 @@ const mockLocation = MockFactory.create(location);
 
 #### Spying/stubbing getters and setters
  * All properties have spies on the getter and setter, even if they weren't in the real object.
- * To access a getter spy, call `mockInstance._spy.property._get`.
- * To access a setter spy, call `mockInstance._spy.property._set`.
+ * Access a getter spy on `mockInstance._spy.property._get`.
+ * Access a setter spy on `mockInstance._spy.property._set`.
  * NOTE: modification to the properties will not be preserved after getter or setter spies are customized
- * NOTE: `expect(mockInstance.someProperty).toBe(...)` will trigger `mockInstance._spy.someProperty._get`. Design the sequence of your assertions to avoid stepping on your own foot.
+ * NOTE: `expect(mockInstance.someProperty).toBe(...)` will trigger `mockInstance._spy.someProperty._get`. Design the sequence of your assertions to avoid shooting yourself in the foot.
 ```TypeScript
   let temp = mockInstance.publicProperty;
   expect(mockInstance._spy.publicProperty._get).toHaveBeenCalled();
@@ -136,14 +136,14 @@ const mockLocation = MockFactory.create(location);
   mockInstance.publicProperty = 42;
   expect(mockInstance._spy.publicProperty._set).toHaveBeenCalledWith(42);
   expect(mockInstance.publicProperty).toBe(42); // pass
-  mockInstance._spy.publicProperty._set.and.callFake(() => { /* noop */});
+  mockInstance._spy.publicProperty._set.and.callFake(() => { /* noop */}); // customized setter
   mockInstance.publicProperty = 100;
   expect(mockInstance.publicProperty).toBe(100); // fail. setter has been customized
 
   mockInstance['privateProperty'] = 100;
   expect(mockInstance._spy.privateProperty._set).toHaveBeenCalledWith(100);
   expect(mockInstance['privateProperty']).toBe(100); // pass
-  mockInstance._spy.privateProperty._get.and.returnValue(42);
+  mockInstance._spy.privateProperty._get.and.returnValue(42); // customized getter
   mockInstance['privateProperty'] = 100;
   expect(mockInstance['privateProperty']).toBe(100); // fail. getter has been customzied
 ```

--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ const mockLocation = MockFactory.create(location);
 ```TypeScript
   const mockInstance = MockFactory.create(location);
   mockInstance.reload(); // use it as if it were the real window.location
+  let temp = mockInstance.search; // use it as if it were the real window.search
+  mockInstance.hash = '#myHash'; // use it as if it were the real window.hash
   mockInstance._spy.reload._func; // returns the spy behind location.reload
   mockInstance._spy.search._get; // returns the spy behind the getter for location.search
   mockInstance._spy.hash._set; // returns the spy behind the setter for location.hash

--- a/README.md
+++ b/README.md
@@ -12,10 +12,14 @@ import { MockFactory} from 'jasmine-mock-factory';
 
 it('should pass', () => {
     const mockInstance = MockFactory.create(SomeClass);
-    mockInstance.doSomething.and.returnValue('awesome!');
 
+    /* arrange */
+    mockInstance._spy.doSomething._func.and.returnValue('awesome!');
+
+    /* act */
     mockInstance.doSomething();  // returns 'awesome!'
 
+    /* assert */
     expect(mockInstance.doSomething).toHaveBeenCalled();
 }
 ```
@@ -62,33 +66,86 @@ const realInstance: RealInterface = new RealClass();
 const mockInstance = MockFactory.create(realInstance);
 ```
 
-### Using a mock
-`MockFactory.create()` will return an object with the same interface as the original object. You can invoke methods and get/set properties on this object. 
-
- * All the public and private methods will have a jasmine.Spy as the initial value. The Spy cannot be overwritten.
- * All the public and private properties will have `undefined` as the initial value. The value can be overwritten with anything.
- 
-### Examples
+#### From window object
 ```TypeScript
-class RealClass {
-  public doSomething(...arg: any[]) { ... }
-  public someProperty = 'whatever';
-}
+/* make sure you have included dom types from the TypeScript library */
+const mockWindow  = MockFactory.create(window);
+const mockDocument = MockFactory.create(document);
+const mockLocation = MockFactory.create(location);
+```
 
-const mockInstance = MockFactory.create(RealClass);
+### Using a mock
+ * `MockFactory.create()` will return an object with the same interface as the real object. You can invoke methods and access properties on this object.
+ * In addition, the mock object provides a `_spy` facade, where you can access and config spies on functions and properties.
+```TypeScript
+  const mockInstance = MockFactory.create(location);
+  mockInstance.reload(); // use it as if it were the real window.location
+  mockInstance._spy.reload._func; // returns the spy behind location.reload
+  mockInstance._spy.search._get; // returns the spy behind the getter for location.search
+```
 
-// get, set property
-expect(mockInstance.someProperty).toBeUndefined();
-mockInstance.someProperty = 'hello';
-expect(mockInstance.someProperty).toBe('hello');
+#### Invoking functions
+ * All methods will have a jasmine.Spy as the initial value. The Spy cannot be overwritten and returns `undefined` by default.
+ * To access protected and private functions, cast the mockInstance `as any` or using bracket notation.
+```TypeScript
+  mockInstance.publicMethod(42); // the spy behind it is invoked with 42
 
-// use function spy
-expect(mockInstance.doSomething).not.toHaveBeenCalled();
+  (mockInstance as any).privateMethod(42);
+  mockInstance['privateMethod'](42);
+```
 
-(mockInstance.doSomething as jasmine.Spy).and.returnValue('awesome!');
+#### Spying/stubbing functions
+ * You can change return values of functions or assert their calls by accessing them directly or throught the `_spy` facade.
+ * To access a function spy, call `mockInstance._spy.functionName._func`.
+ ```TypeScript
+   (mockInstance.publicMethod as jasmine.Spy).and.returnValue(42); // it works, but requires casting
+   mockInstance._spy.publicMethod._func.and.returnValue(42); // recommended!
 
-expect(mockInstance.doSomething(42)).toBe('awesome!');
-expect(mockInstance.doSomething).toHaveBeenCalledWith(42);
+   ((mockInstance as any).privateMethod as jasmine.Spy).and.returnValue(42); // it works, but requires two castings
+   mockInstance._spy.privateMethod._func.and.returnValue(42); // recommended!
+```
+
+#### Accessing properties
+ * All properties have `undefined` as the initial value. The value can be overwritten with anything.
+ * You can read and write access to any property, even if they were readonly in the real object.
+ * To read or write value on a protected or private properties, cast the mockInstance `as any` or using bracket notation.
+ * To write value on a readonly property, cast the mockInstance `as any`. Note that bracket notation won't work.
+ * By default, modification to the properties will be preserved, even if a getter or setter was used in the real object.
+```TypeScript
+  mockInstance.publicProperty = 42;
+  let temp = mockInstance.publicProperty; // temp = 42;
+
+  mockInstance.readonlyProperty = 42; // typescript compiler error
+  (mockInstance as any).readonlyProperty = 42; // no problem
+  mockInstance['readonlyProperty'] = 42; // typescript compiler error
+
+  (mockInstance as any).privateProperty = 'foo';
+  mockInstance['privateProperty'] = 'foo'; // equivalent to above
+```
+
+#### Spying/stubbing getters and setters
+ * All properties have spies on the getter and setter, even if they weren't in the real object.
+ * To access a getter spy, call `mockInstance._spy.property._get`.
+ * To access a setter spy, call `mockInstance._spy.property._set`.
+ * NOTE: modification to the properties will not be preserved after getter or setter spies are customized
+ * NOTE: `expect(mockInstance.someProperty).toBe(...)` will trigger `mockInstance._spy.someProperty._get`. Design the sequence of your asserts to avoid stepping on your own foot.
+```TypeScript
+  let temp = mockInstance.publicProperty;
+  expect(mockInstance._spy.publicProperty._get).toHaveBeenCalled();
+
+  mockInstance.publicProperty = 42;
+  expect(mockInstance._spy.publicProperty._set).toHaveBeenCalledWith(42);
+  expect(mockInstance.publicProperty).toBe(42); // pass
+  mockInstance._spy.publicProperty._set.and.callFake(() => { /* noop */});
+  mockInstance.publicProperty = 100;
+  expect(mockInstance.publicProperty).toBe(100); // fail. setter has been customized
+
+  mockInstance['privateProperty'] = 100;
+  expect(mockInstance._spy.privateProperty._set).toHaveBeenCalledWith(100);
+  expect(mockInstance['privateProperty']).toBe(100); // pass
+  mockInstance._spy.privateProperty._get.and.returnValue(42);
+  mockInstance['privateProperty'] = 100;
+  expect(mockInstance['privateProperty']).toBe(100); // fail. getter has been customzied
 ```
 
 ## Develope

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ const mockLocation = MockFactory.create(location);
  * To access a getter spy, call `mockInstance._spy.property._get`.
  * To access a setter spy, call `mockInstance._spy.property._set`.
  * NOTE: modification to the properties will not be preserved after getter or setter spies are customized
- * NOTE: `expect(mockInstance.someProperty).toBe(...)` will trigger `mockInstance._spy.someProperty._get`. Design the sequence of your asserts to avoid stepping on your own foot.
+ * NOTE: `expect(mockInstance.someProperty).toBe(...)` will trigger `mockInstance._spy.someProperty._get`. Design the sequence of your assertions to avoid stepping on your own foot.
 ```TypeScript
   let temp = mockInstance.publicProperty;
   expect(mockInstance._spy.publicProperty._get).toHaveBeenCalled();

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ const mockLocation = MockFactory.create(location);
   const mockInstance = MockFactory.create(location);
   mockInstance.reload(); // use it as if it were the real window.location
   let temp = mockInstance.search; // use it as if it were the real window.search
-  mockInstance.hash = '#myHash'; // use it as if it were the real window.hash
+  mockInstance.hash = 'myHash'; // use it as if it were the real window.hash
   mockInstance._spy.reload._func; // returns the spy behind location.reload
   mockInstance._spy.search._get; // returns the spy behind the getter for location.search
   mockInstance._spy.hash._set; // returns the spy behind the setter for location.hash

--- a/README.md
+++ b/README.md
@@ -23,6 +23,23 @@ it('should pass', () => {
     expect(mockInstance.doSomething).toHaveBeenCalled();
 }
 ```
+## Quick reference
+```TypeScript
+  /* create a mock from a class*/
+  const mockInstance1 = MockFactory.create(RealClass);
+
+  /* create a mock from an instance*/
+  const mockInstance2 = MockFactory.create(realInstance);
+
+  /* access a function spy */
+  const spy1 = mockInstance._spy.functionName._func
+
+  /* access a getter spy */
+  const spy2 = mockInstance._spy.propertyName._get
+
+  /* access a setter spy */
+  const spy3 = mockInstance._spy.propertyName._set
+```
 
 ## Prerequisite
 
@@ -31,8 +48,8 @@ This util is built with and for [Jasmine](https://jasmine.github.io/) test frame
 This util requires [ES6 Proxy](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) and only contains `*.ts` files that must be compiled with a [TypeScript](https://www.typescriptlang.org/) compiler.
 
 
-
 ## Usage
+
 ### Install
 ```Shell
 npm install jasmine-mock-factory --save-dev
@@ -75,77 +92,90 @@ const mockLocation = MockFactory.create(location);
 ```
 
 ### Using a mock
- * `MockFactory.create()` will return an object with the same interface as the real object. You can invoke methods and access properties on this object.
+ * `MockFactory.create()` will return an object with the same interface as the real object. You can invoke functions and access properties on this object.
  * In addition, the mock object provides a `_spy` facade, where you can access and config spies on functions and properties.
 ```TypeScript
   const mockInstance = MockFactory.create(location);
   mockInstance.reload(); // use it as if it were the real window.location
   mockInstance._spy.reload._func; // returns the spy behind location.reload
   mockInstance._spy.search._get; // returns the spy behind the getter for location.search
+  mockInstance._spy.hash._set; // returns the spy behind the setter for location.hash
 ```
 
 #### Invoking functions
- * All methods will have a `jasmine.Spy` as the initial value. The spy cannot be overwritten and returns `undefined` by default.
+ * All functions will have a `jasmine.Spy` as the initial value. The spy cannot be overwritten and returns `undefined` by default.
  * To access protected and private functions, cast the mockInstance `as any` or use bracket notation.
 ```TypeScript
-  mockInstance.publicMethod(42); // the spy behind it is invoked with 42
+  mockInstance.publicFunction(42); // the spy behind it is invoked with 42
 
-  (mockInstance as any).privateMethod(42);
-  mockInstance['privateMethod'](42);
+  (mockInstance as any).privateFunction(42);
+  mockInstance['privateFunction'](42); // equivalent
 ```
 
 #### Spying/stubbing functions
  * You can change return values of functions or assert their calls by accessing them directly or through the `_spy` facade.
  * Access a function spy on `mockInstance._spy.functionName._func`.
  ```TypeScript
-   mockInstance._spy.publicMethod._func.and.returnValue(42);
-   (mockInstance.publicMethod as jasmine.Spy).and.returnValue(42); // equivalent, but not recommented because it requires casting
+   /* stubbing a public function */
+   mockInstance._spy.publicFunction._func.and.returnValue(42);
+   (mockInstance.publicFunction as jasmine.Spy).and.returnValue(42); // equivalent, but not recommented because it requires casting
 
-   mockInstance._spy.privateMethod._func.and.returnValue(42);
-   ((mockInstance as any).privateMethod as jasmine.Spy).and.returnValue(42); // equivalent, but not recommented because it requires casting twice
+   /* stubbing a private function */
+   mockInstance._spy.privateFunction._func.and.returnValue(42);
+   ((mockInstance as any).privateFunction as jasmine.Spy).and.returnValue(42); // equivalent, but not recommented because it requires casting twice
 ```
 
 #### Accessing properties
  * All properties have `undefined` as the initial value. The value can be overwritten with anything.
  * You have read and write access to any property, even if they were readonly in the real object.
- * To read or write value on a protected or private properties, cast the mockInstance `as any` or use bracket notation.
- * To write value on a readonly property, cast the mockInstance `as any`. Note that bracket notation won't work.
- * By default, modification to the properties will be preserved, even if a getter or setter exists in the real object.
+ * To read or write a protected or private property, cast the mockInstance `as any` or use bracket notation.
+ * To write a readonly property, cast the mockInstance `as any`. The bracket notation won't work.
+ * By default, modification to the properties will persist, even if a getter or setter exists in the real object.
 ```TypeScript
+  /* persist modification */
   mockInstance.publicProperty = 42;
   let temp = mockInstance.publicProperty; // temp = 42;
 
+  /* access readonly property */
   mockInstance.readonlyProperty = 42; // typescript compiler error
   (mockInstance as any).readonlyProperty = 42; // no problem
   mockInstance['readonlyProperty'] = 42; // typescript compiler error
 
+  /* access private property */
   (mockInstance as any).privateProperty = 'foo';
-  mockInstance['privateProperty'] = 'foo'; // equivalent to above
+  mockInstance['privateProperty'] = 'foo'; // equivalent
 ```
 
 #### Spying/stubbing getters and setters
- * All properties have spies on the getter and setter, even if they weren't in the real object.
- * Access a getter spy on `mockInstance._spy.property._get`.
- * Access a setter spy on `mockInstance._spy.property._set`.
- * NOTE: modification to the properties will not be preserved after getter or setter spies are customized
- * NOTE: `expect(mockInstance.someProperty).toBe(...)` will trigger `mockInstance._spy.someProperty._get`. Design the sequence of your assertions to avoid shooting yourself in the foot.
+ * All properties have spies on the getter and setter, even if the getter and setter don't exist in the real object.
+ * Access a getter spy on `mockInstance._spy.propertyName._get`.
+ * Access a setter spy on `mockInstance._spy.propertyName._set`.
+ * NOTE: modification to the properties will not persist after getter or setter spies are customized
+ * NOTE: `expect(mockInstance.someProperty).toBe(...)` will trigger `mockInstance._spy.someProperty._get`. Design the sequence of your assertions carefully to avoid shooting yourself in the foot.
 ```TypeScript
+  /* assert getter calls */
   let temp = mockInstance.publicProperty;
   expect(mockInstance._spy.publicProperty._get).toHaveBeenCalled();
 
+  /* assert setter calls on a public property */
   mockInstance.publicProperty = 42;
   expect(mockInstance._spy.publicProperty._set).toHaveBeenCalledWith(42);
-  expect(mockInstance.publicProperty).toBe(42); // pass
-  mockInstance._spy.publicProperty._set.and.callFake(() => { /* noop */}); // customized setter
-  mockInstance.publicProperty = 100;
-  expect(mockInstance.publicProperty).toBe(100); // fail. setter has been customized
 
-  mockInstance['privateProperty'] = 100;
-  expect(mockInstance._spy.privateProperty._set).toHaveBeenCalledWith(100);
-  expect(mockInstance['privateProperty']).toBe(100); // pass
-  mockInstance._spy.privateProperty._get.and.returnValue(42); // customized getter
-  mockInstance['privateProperty'] = 100;
-  expect(mockInstance['privateProperty']).toBe(100); // fail. getter has been customzied
+  /* customize setter */
+  expect(mockInstance.publicProperty).toBe(42); // pass. setter hasn't been customized
+  mockInstance._spy.publicProperty._set.and.callFake(() => { /* noop */});
+  mockInstance.publicProperty = 100;
+  expect(mockInstance.publicProperty).toBe(100); // fail. expect 42 to be 100. setter was customized
+
+  /* assert setter calls on a private property */
+  mockInstance['privateProperty'] = 42;
+  expect(mockInstance._spy.privateProperty._set).toHaveBeenCalledWith(42);
+
+  /* customize setter */
+  expect(mockInstance['privateProperty']).toBe(42); // pass. setter hasn't been customized
+  mockInstance._spy.privateProperty._get.and.returnValue(100);
+  mockInstance['privateProperty'] = 42;
+  expect(mockInstance['privateProperty']).toBe(42); // fail, expect 100 to be 42. getter was customzied
 ```
 
 ## Develope

--- a/README.md
+++ b/README.md
@@ -173,8 +173,8 @@ const mockLocation = MockFactory.create(location);
   mockInstance['privateProperty'] = 42;
   expect(mockInstance._spy.privateProperty._set).toHaveBeenCalledWith(42);
 
-  /* customize setter */
-  expect(mockInstance['privateProperty']).toBe(42); // pass. setter hasn't been customized
+  /* customize getter */
+  expect(mockInstance['privateProperty']).toBe(42); // pass. getter hasn't been customized
   mockInstance._spy.privateProperty._get.and.returnValue(100);
   mockInstance['privateProperty'] = 42;
   expect(mockInstance['privateProperty']).toBe(42); // fail, expect 100 to be 42. getter was customzied

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jasmine-mock-factory",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "A Jasmine helper for creating mocked classes",
   "license": "MIT",
   "author": "Chuanqi Sun",

--- a/src/lib/index.spec.ts
+++ b/src/lib/index.spec.ts
@@ -129,12 +129,12 @@ describe('MockFactory', () => {
             expect(mockLocation.replace).toHaveBeenCalledWith('https://foobar.com');
         });
 
-        it('should spy getter on window', () => {
+        it('should spy getter on location', () => {
             mockLocation._spy.origin._get.and.returnValue('https://foobar.com');
             expect(mockLocation.origin).toBe('https://foobar.com');
         });
 
-        it('should spy setter on window', () => {
+        it('should spy setter on location', () => {
             mockLocation.host = 'foobar';
             expect(mockLocation._spy.host._set).toHaveBeenCalledWith('foobar');
         });
@@ -146,7 +146,7 @@ describe('MockFactory', () => {
             mockLocalStorage = MockFactory.create(localStorage);
         });
 
-        it('should mock functions on location', () => {
+        it('should mock functions on localStorage', () => {
             expect(mockLocalStorage._spy.getItem._func).not.toHaveBeenCalled();
             expect(mockLocalStorage.getItem).not.toHaveBeenCalled();
             mockLocalStorage.getItem('foobar');
@@ -154,7 +154,7 @@ describe('MockFactory', () => {
             expect(mockLocalStorage.getItem).toHaveBeenCalledWith('foobar');
         });
 
-        it('should spy getter on window', () => {
+        it('should spy getter on localStorage', () => {
             mockLocalStorage._spy.length._get.and.returnValue(42);
             expect(mockLocalStorage.length).toBe(42);
         });

--- a/src/lib/index.spec.ts
+++ b/src/lib/index.spec.ts
@@ -48,11 +48,11 @@ class BaseClass implements IBaseClass {
         return 2;
     }
 
-    protected protectedMethod(arg1: string): number {
+    protected protectedMethod1(arg1: string): number {
         return 3;
     }
 
-    private privateMethod(arg1: string): number {
+    private privateMethod1(arg1: string): number {
         return 5;
     }
 }
@@ -166,7 +166,7 @@ describe('Using mocks', () => {
             mockWindow = MockFactory.create(window);
         });
 
-        it('should mock functions on window', () => {
+        it('should mock functions', () => {
             expect(mockWindow._spy.open._func).not.toHaveBeenCalled();
             expect(mockWindow.open).not.toHaveBeenCalled();
             mockWindow.open('https://foobar.com');
@@ -174,14 +174,19 @@ describe('Using mocks', () => {
             expect(mockWindow.open).toHaveBeenCalledWith('https://foobar.com');
         });
 
-        it('should spy getter on window', () => {
+        it('should spy getter', () => {
             mockWindow._spy.scrollY._get.and.returnValue(42);
             expect(mockWindow.scrollY).toBe(42);
         });
 
-        it('should spy setter on window', () => {
+        it('should spy setter', () => {
             mockWindow.name = 'foobar';
             expect(mockWindow._spy.name._set).toHaveBeenCalledWith('foobar');
+        });
+
+        it('should persist modification on properties', () => {
+            (mockWindow as any).document = 'foobar';
+            expect(mockWindow.document).toBe('foobar');
         });
     });
 
@@ -191,7 +196,7 @@ describe('Using mocks', () => {
             mockLocation = MockFactory.create(location);
         });
 
-        it('should mock functions on location', () => {
+        it('should mock functions', () => {
             expect(mockLocation._spy.replace._func).not.toHaveBeenCalled();
             expect(mockLocation.replace).not.toHaveBeenCalled();
             mockLocation.replace('https://foobar.com');
@@ -199,7 +204,7 @@ describe('Using mocks', () => {
             expect(mockLocation.replace).toHaveBeenCalledWith('https://foobar.com');
         });
 
-        it('should spy getter on location', () => {
+        it('should spy getter', () => {
             mockLocation._spy.origin._get.and.returnValue('https://foobar.com');
             expect(mockLocation.origin).toBe('https://foobar.com');
 
@@ -207,9 +212,14 @@ describe('Using mocks', () => {
             expect(mockLocation.search).toBe('?param=1');
         });
 
-        it('should spy setter on location', () => {
+        it('should spy setter', () => {
             mockLocation.host = 'foobar';
             expect(mockLocation._spy.host._set).toHaveBeenCalledWith('foobar');
+        });
+
+        it('should persist modification on properties', () => {
+            mockLocation.search = '?foo=bar';
+            expect(mockLocation.search).toBe('?foo=bar');
         });
     });
 
@@ -219,7 +229,7 @@ describe('Using mocks', () => {
             mockLocalStorage = MockFactory.create(localStorage);
         });
 
-        it('should mock functions on localStorage', () => {
+        it('should mock functions', () => {
             expect(mockLocalStorage._spy.getItem._func).not.toHaveBeenCalled();
             expect(mockLocalStorage.getItem).not.toHaveBeenCalled();
             mockLocalStorage.getItem('foobar');
@@ -227,369 +237,717 @@ describe('Using mocks', () => {
             expect(mockLocalStorage.getItem).toHaveBeenCalledWith('foobar');
         });
 
-        it('should spy getter on localStorage', () => {
+        it('should spy getter', () => {
             mockLocalStorage._spy.length._get.and.returnValue(42);
+            expect(mockLocalStorage.length).toBe(42);
+        });
+
+        it('should spy setter', () => {
+            (mockLocalStorage as any).length = 42;
+            expect(mockLocalStorage._spy.length._set).toHaveBeenCalledWith(42);
+        });
+
+        it('should persist modification on properties', () => {
+            (mockLocalStorage as any).length = 42;
             expect(mockLocalStorage.length).toBe(42);
         });
     });
 
     function runCommonSpecs() {
-        it('should return undefined for all public properties', () => {
-            expect(commonInstance.publicProperty1).toBeUndefined();
-            expect(commonInstance.publicProperty2).toBeUndefined();
-            expect(commonInstance.publicGetterProperty1).toBeUndefined();
-            expect(commonInstance.publicSetterProperty1).toBeUndefined();
-            expect(commonInstance.publicGetterSetterProperty1).toBeUndefined();
-
-            expect(commonInstance['publicProperty1']).toBeUndefined();
-            expect(commonInstance['publicProperty2']).toBeUndefined();
-            expect(commonInstance['publicGetterProperty1']).toBeUndefined();
-            expect(commonInstance['publicSetterProperty1']).toBeUndefined();
-            expect(commonInstance['publicGetterSetterProperty1']).toBeUndefined();
+        describe('meta', () => {
+            it('should not allow _spyFacade to be replaced', () => {
+                expect(() => commonInstance._spy = {} as any).toThrow();
+            });
         });
 
-        it('should return undefined for all protected properties', () => {
-            expect((commonInstance as any).protectedProperty1).toBeUndefined();
-            expect((commonInstance as any).protectedProperty2).toBeUndefined();
-            expect((commonInstance as any).protectedGetterProperty1).toBeUndefined();
-            expect((commonInstance as any).protectedSetterProperty1).toBeUndefined();
-            expect((commonInstance as any).protectedGetterSetterProperty1).toBeUndefined();
+        describe('properties', () => {
+            it('should return undefined for all public properties', () => {
+                expect(commonInstance.publicProperty1).toBeUndefined();
+                expect(commonInstance.publicProperty2).toBeUndefined();
+                expect(commonInstance.publicGetterProperty1).toBeUndefined();
+                expect(commonInstance.publicSetterProperty1).toBeUndefined();
+                expect(commonInstance.publicGetterSetterProperty1).toBeUndefined();
 
-            expect(commonInstance['protectedProperty1']).toBeUndefined();
-            expect(commonInstance['protectedProperty2']).toBeUndefined();
-            expect(commonInstance['protectedGetterProperty1']).toBeUndefined();
-            expect(commonInstance['protectedSetterProperty1']).toBeUndefined();
-            expect(commonInstance['protectedGetterSetterProperty1']).toBeUndefined();
+                expect(commonInstance['publicProperty1']).toBeUndefined();
+                expect(commonInstance['publicProperty2']).toBeUndefined();
+                expect(commonInstance['publicGetterProperty1']).toBeUndefined();
+                expect(commonInstance['publicSetterProperty1']).toBeUndefined();
+                expect(commonInstance['publicGetterSetterProperty1']).toBeUndefined();
+            });
+
+            it('should return undefined for all protected properties', () => {
+                expect((commonInstance as any).protectedProperty1).toBeUndefined();
+                expect((commonInstance as any).protectedProperty2).toBeUndefined();
+                expect((commonInstance as any).protectedGetterProperty1).toBeUndefined();
+                expect((commonInstance as any).protectedSetterProperty1).toBeUndefined();
+                expect((commonInstance as any).protectedGetterSetterProperty1).toBeUndefined();
+
+                expect(commonInstance['protectedProperty1']).toBeUndefined();
+                expect(commonInstance['protectedProperty2']).toBeUndefined();
+                expect(commonInstance['protectedGetterProperty1']).toBeUndefined();
+                expect(commonInstance['protectedSetterProperty1']).toBeUndefined();
+                expect(commonInstance['protectedGetterSetterProperty1']).toBeUndefined();
+            });
+
+            it('should return undefined for all private properties', () => {
+                expect((commonInstance as any).privateProperty1).toBeUndefined();
+                expect((commonInstance as any).privateProperty2).toBeUndefined();
+                expect((commonInstance as any).privateGetterProperty1).toBeUndefined();
+                expect((commonInstance as any).privateSetterProperty1).toBeUndefined();
+                expect((commonInstance as any).privateGetterSetterProperty1).toBeUndefined();
+
+                expect(commonInstance['privateProperty1']).toBeUndefined();
+                expect(commonInstance['privateProperty2']).toBeUndefined();
+                expect(commonInstance['privateGetterProperty1']).toBeUndefined();
+                expect(commonInstance['privateSetterProperty1']).toBeUndefined();
+                expect(commonInstance['privateGetterSetterProperty1']).toBeUndefined();
+            });
+
+            it('should return undefined for non-exist properties', () => {
+                expect((commonInstance as any).nonExistProperty).toBeUndefined();
+                expect(commonInstance['nonExistProperty']).toBeUndefined();
+            });
+
+            it('should persist first modifications on properties', () => {
+                commonInstance.publicProperty1 = 'new-value';
+                expect(commonInstance.publicProperty1).toBe('new-value');
+                (commonInstance as any).publicGetterProperty1 = 'new-value';
+                expect(commonInstance.publicGetterProperty1).toBe('new-value');
+                commonInstance.publicSetterProperty1 = 'new-value';
+                expect(commonInstance.publicSetterProperty1).toBe('new-value');
+                commonInstance.publicGetterSetterProperty1 = 'new-value';
+                expect(commonInstance.publicGetterSetterProperty1).toBe('new-value');
+
+                commonInstance['protectedProperty1'] = 'new-value';
+                expect(commonInstance['protectedProperty1']).toBe('new-value');
+                commonInstance['protectedGetterProperty1'] = 'new-value';
+                expect(commonInstance['protectedGetterProperty1']).toBe('new-value');
+                commonInstance['protectedSetterProperty1'] = 'new-value';
+                expect(commonInstance['protectedSetterProperty1']).toBe('new-value');
+                commonInstance['protectedGetterSetterProperty1'] = 'new-value';
+                expect(commonInstance['protectedGetterSetterProperty1']).toBe('new-value');
+
+                commonInstance['privateProperty1'] = 'new-value';
+                expect(commonInstance['privateProperty1']).toBe('new-value');
+                commonInstance['privateGetterProperty1'] = 'new-value';
+                expect(commonInstance['privateGetterProperty1']).toBe('new-value');
+                commonInstance['privateSetterProperty1'] = 'new-value';
+                expect(commonInstance['privateSetterProperty1']).toBe('new-value');
+                commonInstance['privateGetterSetterProperty1'] = 'new-value';
+                expect(commonInstance['privateGetterSetterProperty1']).toBe('new-value');
+
+                commonInstance['nonExistProperty'] = 'new-value';
+                expect(commonInstance['nonExistProperty']).toBe('new-value');
+            });
+
+            it('should persist all modifications on properties', () => {
+                commonInstance.publicProperty1 = 'new-value-1';
+                commonInstance.publicProperty1 = 'new-value-2';
+                expect(commonInstance.publicProperty1).toBe('new-value-2');
+                (commonInstance as any).publicGetterProperty1 = 'new-value-1';
+                (commonInstance as any).publicGetterProperty1 = 'new-value-2';
+                expect(commonInstance.publicGetterProperty1).toBe('new-value-2');
+                commonInstance.publicSetterProperty1 = 'new-value-1';
+                commonInstance.publicSetterProperty1 = 'new-value-2';
+                expect(commonInstance.publicSetterProperty1).toBe('new-value-2');
+                commonInstance.publicGetterSetterProperty1 = 'new-value-1';
+                commonInstance.publicGetterSetterProperty1 = 'new-value-2';
+                expect(commonInstance.publicGetterSetterProperty1).toBe('new-value-2');
+
+                commonInstance['protectedProperty1'] = 'new-value-1';
+                commonInstance['protectedProperty1'] = 'new-value-2';
+                expect(commonInstance['protectedProperty1']).toBe('new-value-2');
+                commonInstance['protectedGetterProperty1'] = 'new-value-1';
+                commonInstance['protectedGetterProperty1'] = 'new-value-2';
+                expect(commonInstance['protectedGetterProperty1']).toBe('new-value-2');
+                commonInstance['protectedSetterProperty1'] = 'new-value-1';
+                commonInstance['protectedSetterProperty1'] = 'new-value-2';
+                expect(commonInstance['protectedSetterProperty1']).toBe('new-value-2');
+                commonInstance['protectedGetterSetterProperty1'] = 'new-value-1';
+                commonInstance['protectedGetterSetterProperty1'] = 'new-value-2';
+                expect(commonInstance['protectedGetterSetterProperty1']).toBe('new-value-2');
+
+                commonInstance['privateProperty1'] = 'new-value-1';
+                commonInstance['privateProperty1'] = 'new-value-2';
+                expect(commonInstance['privateProperty1']).toBe('new-value-2');
+                commonInstance['privateGetterProperty1'] = 'new-value-1';
+                commonInstance['privateGetterProperty1'] = 'new-value-2';
+                expect(commonInstance['privateGetterProperty1']).toBe('new-value-2');
+                commonInstance['privateSetterProperty1'] = 'new-value-1';
+                commonInstance['privateSetterProperty1'] = 'new-value-2';
+                expect(commonInstance['privateSetterProperty1']).toBe('new-value-2');
+                commonInstance['privateGetterSetterProperty1'] = 'new-value-1';
+                commonInstance['privateGetterSetterProperty1'] = 'new-value-2';
+                expect(commonInstance['privateGetterSetterProperty1']).toBe('new-value-2');
+
+                commonInstance['nonExistProperty'] = 'new-value-1';
+                commonInstance['nonExistProperty'] = 'new-value-2';
+                expect(commonInstance['nonExistProperty']).toBe('new-value-2');
+            });
+
+            it('should spy getters before they are used', () => {
+                expect(commonInstance._spy.publicProperty1._get).not.toHaveBeenCalled();
+                expect(commonInstance._spy.publicGetterProperty1._get).not.toHaveBeenCalled();
+                expect(commonInstance._spy.publicSetterProperty1._get).not.toHaveBeenCalled();
+                expect(commonInstance._spy.publicGetterSetterProperty1._get).not.toHaveBeenCalled();
+
+                expect(commonInstance._spy['protectedProperty1']._get).not.toHaveBeenCalled();
+                expect(commonInstance._spy['protectedGetterProperty1']._get).not.toHaveBeenCalled();
+                expect(commonInstance._spy['protectedSetterProperty1']._get).not.toHaveBeenCalled();
+                expect(commonInstance._spy['protectedGetterSetterProperty1']._get).not.toHaveBeenCalled();
+
+                expect(commonInstance._spy['privateProperty1']._get).not.toHaveBeenCalled();
+                expect(commonInstance._spy['privateGetterProperty1']._get).not.toHaveBeenCalled();
+                expect(commonInstance._spy['privateSetterProperty1']._get).not.toHaveBeenCalled();
+                expect(commonInstance._spy['privateGetterSetterProperty1']._get).not.toHaveBeenCalled();
+
+                expect(commonInstance._spy['nonExistProperty']._get).not.toHaveBeenCalled();
+            });
+
+            it('should spy setters before they are used', () => {
+                expect(commonInstance._spy.publicProperty1._set).not.toHaveBeenCalled();
+                expect(commonInstance._spy.publicGetterProperty1._set).not.toHaveBeenCalled();
+                expect(commonInstance._spy.publicSetterProperty1._set).not.toHaveBeenCalled();
+                expect(commonInstance._spy.publicGetterSetterProperty1._set).not.toHaveBeenCalled();
+
+                expect(commonInstance._spy['protectedProperty1']._set).not.toHaveBeenCalled();
+                expect(commonInstance._spy['protectedGetterProperty1']._set).not.toHaveBeenCalled();
+                expect(commonInstance._spy['protectedSetterProperty1']._set).not.toHaveBeenCalled();
+                expect(commonInstance._spy['protectedGetterSetterProperty1']._set).not.toHaveBeenCalled();
+
+                expect(commonInstance._spy['privateProperty1']._set).not.toHaveBeenCalled();
+                expect(commonInstance._spy['privateGetterProperty1']._set).not.toHaveBeenCalled();
+                expect(commonInstance._spy['privateSetterProperty1']._set).not.toHaveBeenCalled();
+                expect(commonInstance._spy['privateGetterSetterProperty1']._set).not.toHaveBeenCalled();
+
+                expect(commonInstance._spy['nonExistProperty']._set).not.toHaveBeenCalled();
+            });
+
+            it('should record calls on getters', () => {
+                let temp1 = commonInstance.publicProperty1;
+                temp1 = commonInstance.publicGetterProperty1;
+                temp1 = commonInstance.publicSetterProperty1;
+                temp1 = commonInstance.publicGetterSetterProperty1;
+                expect(commonInstance._spy.publicProperty1._get).toHaveBeenCalled();
+                expect(commonInstance._spy.publicGetterProperty1._get).toHaveBeenCalled();
+                expect(commonInstance._spy.publicSetterProperty1._get).toHaveBeenCalled();
+                expect(commonInstance._spy.publicGetterSetterProperty1._get).toHaveBeenCalled();
+                temp1 = commonInstance.publicProperty1;
+                temp1 = commonInstance.publicGetterProperty1;
+                temp1 = commonInstance.publicSetterProperty1;
+                temp1 = commonInstance.publicGetterSetterProperty1;
+                expect(commonInstance._spy.publicProperty1._get).toHaveBeenCalledTimes(2);
+                expect(commonInstance._spy.publicGetterProperty1._get).toHaveBeenCalledTimes(2);
+                expect(commonInstance._spy.publicSetterProperty1._get).toHaveBeenCalledTimes(2);
+                expect(commonInstance._spy.publicGetterSetterProperty1._get).toHaveBeenCalledTimes(2);
+
+                temp1 = commonInstance['protectedProperty1'];
+                temp1 = commonInstance['protectedGetterProperty1'];
+                temp1 = commonInstance['protectedSetterProperty1'];
+                temp1 = commonInstance['protectedGetterSetterProperty1'];
+                expect(commonInstance._spy['protectedProperty1']._get).toHaveBeenCalled();
+                expect(commonInstance._spy['protectedGetterProperty1']._get).toHaveBeenCalled();
+                expect(commonInstance._spy['protectedSetterProperty1']._get).toHaveBeenCalled();
+                expect(commonInstance._spy['protectedGetterSetterProperty1']._get).toHaveBeenCalled();
+                temp1 = commonInstance['protectedProperty1'];
+                temp1 = commonInstance['protectedGetterProperty1'];
+                temp1 = commonInstance['protectedSetterProperty1'];
+                temp1 = commonInstance['protectedGetterSetterProperty1'];
+                expect(commonInstance._spy['protectedProperty1']._get).toHaveBeenCalledTimes(2);
+                expect(commonInstance._spy['protectedGetterProperty1']._get).toHaveBeenCalledTimes(2);
+                expect(commonInstance._spy['protectedSetterProperty1']._get).toHaveBeenCalledTimes(2);
+                expect(commonInstance._spy['protectedGetterSetterProperty1']._get).toHaveBeenCalledTimes(2);
+
+                temp1 = commonInstance['privateProperty1'];
+                temp1 = commonInstance['privateGetterProperty1'];
+                temp1 = commonInstance['privateSetterProperty1'];
+                temp1 = commonInstance['privateGetterSetterProperty1'];
+                expect(commonInstance._spy['privateProperty1']._get).toHaveBeenCalled();
+                expect(commonInstance._spy['privateGetterProperty1']._get).toHaveBeenCalled();
+                expect(commonInstance._spy['privateSetterProperty1']._get).toHaveBeenCalled();
+                expect(commonInstance._spy['privateGetterSetterProperty1']._get).toHaveBeenCalled();
+                temp1 = commonInstance['privateProperty1'];
+                temp1 = commonInstance['privateGetterProperty1'];
+                temp1 = commonInstance['privateSetterProperty1'];
+                temp1 = commonInstance['privateGetterSetterProperty1'];
+                expect(commonInstance._spy['privateProperty1']._get).toHaveBeenCalledTimes(2);
+                expect(commonInstance._spy['privateGetterProperty1']._get).toHaveBeenCalledTimes(2);
+                expect(commonInstance._spy['privateSetterProperty1']._get).toHaveBeenCalledTimes(2);
+                expect(commonInstance._spy['privateGetterSetterProperty1']._get).toHaveBeenCalledTimes(2);
+
+                temp1 = commonInstance['nonExistProperty'];
+                expect(commonInstance._spy['nonExistProperty']._get).toHaveBeenCalled();
+                temp1 = commonInstance['nonExistProperty'];
+                expect(commonInstance._spy['nonExistProperty']._get).toHaveBeenCalledTimes(2);
+            });
+
+            it('should record calls on setters', () => {
+                commonInstance.publicProperty1 = 'new-value';
+                (commonInstance as any).publicGetterProperty1 = 'new-value';
+                commonInstance.publicSetterProperty1 = 'new-value';
+                commonInstance.publicGetterSetterProperty1 = 'new-value';
+                expect(commonInstance._spy.publicProperty1._set).toHaveBeenCalledWith('new-value');
+                expect(commonInstance._spy.publicGetterProperty1._set).toHaveBeenCalledWith('new-value');
+                expect(commonInstance._spy.publicSetterProperty1._set).toHaveBeenCalledWith('new-value');
+                expect(commonInstance._spy.publicGetterSetterProperty1._set).toHaveBeenCalledWith('new-value');
+                commonInstance.publicProperty1 = 'new-value';
+                (commonInstance as any).publicGetterProperty1 = 'new-value';
+                commonInstance.publicSetterProperty1 = 'new-value';
+                commonInstance.publicGetterSetterProperty1 = 'new-value';
+                expect(commonInstance._spy.publicProperty1._set).toHaveBeenCalledTimes(2);
+                expect(commonInstance._spy.publicGetterProperty1._set).toHaveBeenCalledTimes(2);
+                expect(commonInstance._spy.publicSetterProperty1._set).toHaveBeenCalledTimes(2);
+                expect(commonInstance._spy.publicGetterSetterProperty1._set).toHaveBeenCalledTimes(2);
+
+                commonInstance['protectedProperty1'] = 'new-value';
+                commonInstance['protectedGetterProperty1'] = 'new-value';
+                commonInstance['protectedSetterProperty1'] = 'new-value';
+                commonInstance['protectedGetterSetterProperty1'] = 'new-value';
+                expect(commonInstance._spy['protectedProperty1']._set).toHaveBeenCalledWith('new-value');
+                expect(commonInstance._spy['protectedGetterProperty1']._set).toHaveBeenCalledWith('new-value');
+                expect(commonInstance._spy['protectedSetterProperty1']._set).toHaveBeenCalledWith('new-value');
+                expect(commonInstance._spy['protectedGetterSetterProperty1']._set).toHaveBeenCalledWith('new-value');
+                commonInstance['protectedProperty1'] = 'new-value';
+                commonInstance['protectedGetterProperty1'] = 'new-value';
+                commonInstance['protectedSetterProperty1'] = 'new-value';
+                commonInstance['protectedGetterSetterProperty1'] = 'new-value';
+                expect(commonInstance._spy['protectedProperty1']._set).toHaveBeenCalledTimes(2);
+                expect(commonInstance._spy['protectedGetterProperty1']._set).toHaveBeenCalledTimes(2);
+                expect(commonInstance._spy['protectedSetterProperty1']._set).toHaveBeenCalledTimes(2);
+                expect(commonInstance._spy['protectedGetterSetterProperty1']._set).toHaveBeenCalledTimes(2);
+
+                commonInstance['privateProperty1'] = 'new-value';
+                commonInstance['privateGetterProperty1'] = 'new-value';
+                commonInstance['privateSetterProperty1'] = 'new-value';
+                commonInstance['privateGetterSetterProperty1'] = 'new-value';
+                expect(commonInstance._spy['privateProperty1']._set).toHaveBeenCalledWith('new-value');
+                expect(commonInstance._spy['privateGetterProperty1']._set).toHaveBeenCalledWith('new-value');
+                expect(commonInstance._spy['privateSetterProperty1']._set).toHaveBeenCalledWith('new-value');
+                expect(commonInstance._spy['privateGetterSetterProperty1']._set).toHaveBeenCalledWith('new-value');
+                commonInstance['privateProperty1'] = 'new-value';
+                commonInstance['privateGetterProperty1'] = 'new-value';
+                commonInstance['privateSetterProperty1'] = 'new-value';
+                commonInstance['privateGetterSetterProperty1'] = 'new-value';
+                expect(commonInstance._spy['privateProperty1']._set).toHaveBeenCalledTimes(2);
+                expect(commonInstance._spy['privateGetterProperty1']._set).toHaveBeenCalledTimes(2);
+                expect(commonInstance._spy['privateSetterProperty1']._set).toHaveBeenCalledTimes(2);
+                expect(commonInstance._spy['privateGetterSetterProperty1']._set).toHaveBeenCalledTimes(2);
+
+                commonInstance['nonExistProperty'] = 'new-value';
+                expect(commonInstance._spy['nonExistProperty']._set).toHaveBeenCalledWith('new-value');
+                commonInstance['nonExistProperty'] = 'new-value';
+                expect(commonInstance._spy['nonExistProperty']._set).toHaveBeenCalledTimes(2);
+            });
+
+            it('should modify results from getters before they are used', () => {
+                commonInstance._spy.publicProperty1._get.and.returnValue('new-value-1');
+                commonInstance._spy.publicGetterProperty1._get.and.returnValue('new-value-1');
+                commonInstance._spy.publicSetterProperty1._get.and.returnValue('new-value-1');
+                commonInstance._spy.publicGetterSetterProperty1._get.and.returnValue('new-value-1');
+                expect(commonInstance.publicProperty1).toBe('new-value-1');
+                expect(commonInstance.publicGetterProperty1).toBe('new-value-1');
+                expect(commonInstance.publicSetterProperty1).toBe('new-value-1');
+                expect(commonInstance.publicGetterSetterProperty1).toBe('new-value-1');
+
+                commonInstance._spy['protectedProperty1']._get.and.returnValue('new-value-1');
+                commonInstance._spy['protectedGetterProperty1']._get.and.returnValue('new-value-1');
+                commonInstance._spy['protectedSetterProperty1']._get.and.returnValue('new-value-1');
+                commonInstance._spy['protectedGetterSetterProperty1']._get.and.returnValue('new-value-1');
+                expect(commonInstance['protectedProperty1']).toBe('new-value-1');
+                expect(commonInstance['protectedGetterProperty1']).toBe('new-value-1');
+                expect(commonInstance['protectedSetterProperty1']).toBe('new-value-1');
+                expect(commonInstance['protectedGetterSetterProperty1']).toBe('new-value-1');
+
+                commonInstance._spy['privateProperty1']._get.and.returnValue('new-value-1');
+                commonInstance._spy['privateGetterProperty1']._get.and.returnValue('new-value-1');
+                commonInstance._spy['privateSetterProperty1']._get.and.returnValue('new-value-1');
+                commonInstance._spy['privateGetterSetterProperty1']._get.and.returnValue('new-value-1');
+                expect(commonInstance['privateProperty1']).toBe('new-value-1');
+                expect(commonInstance['privateGetterProperty1']).toBe('new-value-1');
+                expect(commonInstance['privateSetterProperty1']).toBe('new-value-1');
+                expect(commonInstance['privateGetterSetterProperty1']).toBe('new-value-1');
+
+                commonInstance._spy['nonExistProperty']._get.and.returnValue('new-value-1');
+                expect(commonInstance['nonExistProperty']).toBe('new-value-1');
+            });
+
+            it('should modify results from getters after they are used', () => {
+                let temp = commonInstance.publicProperty1;
+                temp = commonInstance.publicGetterProperty1;
+                temp = commonInstance.publicSetterProperty1;
+                temp = commonInstance.publicGetterSetterProperty1;
+                commonInstance._spy.publicProperty1._get.and.returnValue('new-value-1');
+                commonInstance._spy.publicGetterProperty1._get.and.returnValue('new-value-1');
+                commonInstance._spy.publicSetterProperty1._get.and.returnValue('new-value-1');
+                commonInstance._spy.publicGetterSetterProperty1._get.and.returnValue('new-value-1');
+                expect(commonInstance.publicProperty1).toBe('new-value-1');
+                expect(commonInstance.publicGetterProperty1).toBe('new-value-1');
+                expect(commonInstance.publicSetterProperty1).toBe('new-value-1');
+                expect(commonInstance.publicGetterSetterProperty1).toBe('new-value-1');
+
+                temp = commonInstance['protectedProperty1'];
+                temp = commonInstance['protectedGetterProperty1'];
+                temp = commonInstance['protectedSetterProperty1'];
+                temp = commonInstance['protectedGetterSetterProperty1'];
+                commonInstance._spy['protectedProperty1']._get.and.returnValue('new-value-1');
+                commonInstance._spy['protectedGetterProperty1']._get.and.returnValue('new-value-1');
+                commonInstance._spy['protectedSetterProperty1']._get.and.returnValue('new-value-1');
+                commonInstance._spy['protectedGetterSetterProperty1']._get.and.returnValue('new-value-1');
+                expect(commonInstance['protectedProperty1']).toBe('new-value-1');
+                expect(commonInstance['protectedGetterProperty1']).toBe('new-value-1');
+                expect(commonInstance['protectedSetterProperty1']).toBe('new-value-1');
+                expect(commonInstance['protectedGetterSetterProperty1']).toBe('new-value-1');
+
+                temp = commonInstance['privateProperty1'];
+                temp = commonInstance['privateGetterProperty1'];
+                temp = commonInstance['privateSetterProperty1'];
+                temp = commonInstance['privateGetterSetterProperty1']
+                commonInstance._spy['privateProperty1']._get.and.returnValue('new-value-1');
+                commonInstance._spy['privateGetterProperty1']._get.and.returnValue('new-value-1');
+                commonInstance._spy['privateSetterProperty1']._get.and.returnValue('new-value-1');
+                commonInstance._spy['privateGetterSetterProperty1']._get.and.returnValue('new-value-1');
+                expect(commonInstance['privateProperty1']).toBe('new-value-1');
+                expect(commonInstance['privateGetterProperty1']).toBe('new-value-1');
+                expect(commonInstance['privateSetterProperty1']).toBe('new-value-1');
+                expect(commonInstance['privateGetterSetterProperty1']).toBe('new-value-1');
+
+                temp = commonInstance['nonExistProperty'];
+                commonInstance._spy['nonExistProperty']._get.and.returnValue('new-value-1');
+                expect(commonInstance['nonExistProperty']).toBe('new-value-1');
+            });
+
+            it('should re-modify results from getters', () => {
+                commonInstance._spy.publicProperty1._get.and.returnValue('new-value-1');
+                commonInstance._spy.publicGetterProperty1._get.and.returnValue('new-value-1');
+                commonInstance._spy.publicSetterProperty1._get.and.returnValue('new-value-1');
+                commonInstance._spy.publicGetterSetterProperty1._get.and.returnValue('new-value-1');
+                commonInstance._spy.publicProperty1._get.and.returnValue('new-value-2');
+                commonInstance._spy.publicGetterProperty1._get.and.returnValue('new-value-2');
+                commonInstance._spy.publicSetterProperty1._get.and.returnValue('new-value-2');
+                commonInstance._spy.publicGetterSetterProperty1._get.and.returnValue('new-value-2');
+                expect(commonInstance.publicProperty1).toBe('new-value-2');
+                expect(commonInstance.publicGetterProperty1).toBe('new-value-2');
+                expect(commonInstance.publicSetterProperty1).toBe('new-value-2');
+                expect(commonInstance.publicGetterSetterProperty1).toBe('new-value-2');
+
+                commonInstance._spy['protectedProperty1']._get.and.returnValue('new-value-1');
+                commonInstance._spy['protectedGetterProperty1']._get.and.returnValue('new-value-1');
+                commonInstance._spy['protectedSetterProperty1']._get.and.returnValue('new-value-1');
+                commonInstance._spy['protectedGetterSetterProperty1']._get.and.returnValue('new-value-1');
+                commonInstance._spy['protectedProperty1']._get.and.returnValue('new-value-2');
+                commonInstance._spy['protectedGetterProperty1']._get.and.returnValue('new-value-2');
+                commonInstance._spy['protectedSetterProperty1']._get.and.returnValue('new-value-2');
+                commonInstance._spy['protectedGetterSetterProperty1']._get.and.returnValue('new-value-2');
+                expect(commonInstance['protectedProperty1']).toBe('new-value-2');
+                expect(commonInstance['protectedGetterProperty1']).toBe('new-value-2');
+                expect(commonInstance['protectedSetterProperty1']).toBe('new-value-2');
+                expect(commonInstance['protectedGetterSetterProperty1']).toBe('new-value-2');
+
+                commonInstance._spy['privateProperty1']._get.and.returnValue('new-value-1');
+                commonInstance._spy['privateGetterProperty1']._get.and.returnValue('new-value-1');
+                commonInstance._spy['privateSetterProperty1']._get.and.returnValue('new-value-1');
+                commonInstance._spy['privateGetterSetterProperty1']._get.and.returnValue('new-value-1');
+                commonInstance._spy['privateProperty1']._get.and.returnValue('new-value-2');
+                commonInstance._spy['privateGetterProperty1']._get.and.returnValue('new-value-2');
+                commonInstance._spy['privateSetterProperty1']._get.and.returnValue('new-value-2');
+                commonInstance._spy['privateGetterSetterProperty1']._get.and.returnValue('new-value-2');
+                expect(commonInstance['privateProperty1']).toBe('new-value-2');
+                expect(commonInstance['privateGetterProperty1']).toBe('new-value-2');
+                expect(commonInstance['privateSetterProperty1']).toBe('new-value-2');
+                expect(commonInstance['privateGetterSetterProperty1']).toBe('new-value-2');
+
+                commonInstance._spy['nonExistProperty']._get.and.returnValue('new-value-1');
+                commonInstance._spy['nonExistProperty']._get.and.returnValue('new-value-2');
+                expect(commonInstance['nonExistProperty']).toBe('new-value-2');
+            });
+
+            it('should not allow spiedMembers to be replaced via spyFacade', () => {
+                expect(() => commonInstance._spy.publicProperty1 = {}).toThrow();
+                expect(() => (commonInstance._spy as any).publicGetterProperty1 = {}).toThrow();
+                expect(() => commonInstance._spy.publicSetterProperty1 = {}).toThrow();
+                expect(() => commonInstance._spy.publicGetterSetterProperty1 = {}).toThrow();
+
+                expect(() => (commonInstance._spy['protectedProperty1'] = {})).toThrow();
+                expect(() => (commonInstance._spy['protectedGetterProperty1'] = {})).toThrow();
+                expect(() => (commonInstance._spy['protectedSetterProperty1'] = {})).toThrow();
+                expect(() => (commonInstance._spy['protectedGetterSetterProperty1'] = {})).toThrow();
+
+                expect(() => (commonInstance._spy['privateProperty1'] = {})).toThrow();
+                expect(() => (commonInstance._spy['privateGetterProperty1'] = {})).toThrow();
+                expect(() => (commonInstance._spy['privateSetterProperty1'] = {})).toThrow();
+                expect(() => (commonInstance._spy['privateGetterSetterProperty1'] = {})).toThrow();
+
+                expect(() => (commonInstance._spy['nonExistProperty'] = {})).toThrow();
+            });
+
+            it('should not allow reading _func on properties', () => {
+                expect(() => commonInstance._spy.publicProperty1._func).toThrow();
+                expect(() => commonInstance._spy.publicGetterProperty1._func).toThrow();
+                expect(() => commonInstance._spy.publicSetterProperty1._func).toThrow();
+                expect(() => commonInstance._spy.publicGetterSetterProperty1._func).toThrow();
+
+                expect(() => (commonInstance._spy['protectedProperty1']._func)).toThrow();
+                expect(() => (commonInstance._spy['protectedGetterProperty1']._func)).toThrow();
+                expect(() => (commonInstance._spy['protectedSetterProperty1']._func)).toThrow();
+                expect(() => (commonInstance._spy['protectedGetterSetterProperty1']._func)).toThrow();
+
+                expect(() => (commonInstance._spy['privateProperty1']._func)).toThrow();
+                expect(() => (commonInstance._spy['privateGetterProperty1']._func)).toThrow();
+                expect(() => (commonInstance._spy['privateSetterProperty1']._func)).toThrow();
+                expect(() => (commonInstance._spy['privateGetterSetterProperty1']._func)).toThrow();
+
+                expect(() => (commonInstance._spy['nonExistProperty']._func)).toThrow();
+            });
+
+            it('should not allow writing _func on properties', () => {
+                expect(() => commonInstance._spy.publicProperty1._func = jasmine.createSpy('whatever')).toThrow();
+                expect(() => commonInstance._spy.publicGetterProperty1._func = jasmine.createSpy('whatever')).toThrow();
+                expect(() => commonInstance._spy.publicSetterProperty1._func = jasmine.createSpy('whatever')).toThrow();
+                expect(() => commonInstance._spy.publicGetterSetterProperty1._func = jasmine.createSpy('whatever')).toThrow();
+
+                expect(() => (commonInstance._spy['protectedProperty1']._func = jasmine.createSpy('whatever'))).toThrow();
+                expect(() => (commonInstance._spy['protectedGetterProperty1']._func = jasmine.createSpy('whatever'))).toThrow();
+                expect(() => (commonInstance._spy['protectedSetterProperty1']._func = jasmine.createSpy('whatever'))).toThrow();
+                expect(() => (commonInstance._spy['protectedGetterSetterProperty1']._func = jasmine.createSpy('whatever'))).toThrow();
+
+                expect(() => (commonInstance._spy['privateProperty1']._func = jasmine.createSpy('whatever'))).toThrow();
+                expect(() => (commonInstance._spy['privateGetterProperty1']._func = jasmine.createSpy('whatever'))).toThrow();
+                expect(() => (commonInstance._spy['privateSetterProperty1']._func = jasmine.createSpy('whatever'))).toThrow();
+                expect(() => (commonInstance._spy['privateGetterSetterProperty1']._func = jasmine.createSpy('whatever'))).toThrow();
+
+                expect(() => (commonInstance._spy['nonExistProperty']._func = jasmine.createSpy('whatever'))).toThrow();
+            });
         });
 
-        it('should return undefined for all private properties', () => {
-            expect((commonInstance as any).privateProperty1).toBeUndefined();
-            expect((commonInstance as any).privateProperty2).toBeUndefined();
-            expect((commonInstance as any).privateGetterProperty1).toBeUndefined();
-            expect((commonInstance as any).privateSetterProperty1).toBeUndefined();
-            expect((commonInstance as any).privateGetterSetterProperty1).toBeUndefined();
+        describe('methods', () => {
+            it('should return spy for all methods', () => {
+                expect(commonInstance.publicMethod1).not.toHaveBeenCalled();
+                expect(commonInstance.publicMethod1).not.toHaveBeenCalled();
+                expect((commonInstance as any).protectedMethod1).not.toHaveBeenCalled();
+                expect((commonInstance as any).protectedMethod1).not.toHaveBeenCalled();
+                expect((commonInstance as any).privateMethod1).not.toHaveBeenCalled();
+                expect((commonInstance as any).privateMethod1).not.toHaveBeenCalled();
 
-            expect(commonInstance['privateProperty1']).toBeUndefined();
-            expect(commonInstance['privateProperty2']).toBeUndefined();
-            expect(commonInstance['privateGetterProperty1']).toBeUndefined();
-            expect(commonInstance['privateSetterProperty1']).toBeUndefined();
-            expect(commonInstance['privateGetterSetterProperty1']).toBeUndefined();
-        });
+                expect(commonInstance['publicMethod1']).not.toHaveBeenCalled();
+                expect(commonInstance['publicMethod1']).not.toHaveBeenCalled();
+                expect(commonInstance['protectedMethod1']).not.toHaveBeenCalled();
+                expect(commonInstance['protectedMethod1']).not.toHaveBeenCalled();
+                expect(commonInstance['privateMethod1']).not.toHaveBeenCalled();
+                expect(commonInstance['privateMethod1']).not.toHaveBeenCalled();
+            });
 
-        it('should return undefined for non-exist properties', () => {
-            expect((commonInstance as any).nonExistProperty).toBeUndefined();
-            expect(commonInstance['nonExistProperty']).toBeUndefined();
-        });
+            it('should return spy from spyFacade for all methods', () => {
+                expect(commonInstance._spy.publicMethod1._func).not.toHaveBeenCalled();
+                expect(commonInstance._spy.publicMethod1._func).not.toHaveBeenCalled();
+                expect((commonInstance._spy as any).protectedMethod1._func).not.toHaveBeenCalled();
+                expect((commonInstance._spy as any).protectedMethod1._func).not.toHaveBeenCalled();
+                expect((commonInstance._spy as any).privateMethod1._func).not.toHaveBeenCalled();
+                expect((commonInstance._spy as any).privateMethod1._func).not.toHaveBeenCalled();
 
-        it('should persist the first modification on properties', () => {
-            commonInstance.publicProperty1 = 'new-value';
-            expect(commonInstance.publicProperty1).toBe('new-value');
+                expect(commonInstance._spy.publicMethod1._func).not.toHaveBeenCalled();
+                expect(commonInstance._spy.publicMethod1._func).not.toHaveBeenCalled();
+                expect(commonInstance._spy['protectedMethod1']._func).not.toHaveBeenCalled();
+                expect(commonInstance._spy['protectedMethod1']._func).not.toHaveBeenCalled();
+                expect(commonInstance._spy['privateMethod1']._func).not.toHaveBeenCalled();
+                expect(commonInstance._spy['privateMethod1']._func).not.toHaveBeenCalled();
+            });
 
-            commonInstance['protectedProperty1'] = 'new-value';
-            expect(commonInstance['protectedProperty1']).toBe('new-value');
+            it('should register calls on each spy', () => {
+                commonInstance.publicMethod1('value-1');
+                expect(commonInstance.publicMethod1).toHaveBeenCalledWith('value-1');
+                commonInstance.publicMethod1('value-2');
+                expect(commonInstance.publicMethod1).toHaveBeenCalledWith('value-2');
+                expect(commonInstance.publicMethod1).toHaveBeenCalledTimes(2);
 
-            commonInstance['privateProperty1'] = 'new-value';
-            expect(commonInstance['privateProperty1']).toBe('new-value');
+                (commonInstance as any).protectedMethod1('value-1');
+                expect((commonInstance as any).protectedMethod1).toHaveBeenCalledWith('value-1');
+                (commonInstance as any).protectedMethod1('value-2');
+                expect((commonInstance as any).protectedMethod1).toHaveBeenCalledWith('value-2');
+                expect((commonInstance as any).protectedMethod1).toHaveBeenCalledTimes(2);
 
-            commonInstance['nonExistProperty'] = 'new-value';
-            expect(commonInstance['nonExistProperty']).toBe('new-value');
-        });
+                (commonInstance as any).privateMethod1('value-1');
+                expect((commonInstance as any).privateMethod1).toHaveBeenCalledWith('value-1');
+                (commonInstance as any).privateMethod1('value-2');
+                expect((commonInstance as any).privateMethod1).toHaveBeenCalledWith('value-2');
+                expect((commonInstance as any).privateMethod1).toHaveBeenCalledTimes(2);
+            });
 
-        it('should persist all modifications on properties', () => {
-            commonInstance.publicProperty1 = 'new-value-1';
-            commonInstance.publicProperty1 = 'new-value-2';
-            expect(commonInstance.publicProperty1).toBe('new-value-2');
+            it('should register calls on each spy accessed from the spyFacade', () => {
+                commonInstance._spy.publicMethod1._func('value-1');
+                expect(commonInstance._spy.publicMethod1._func).toHaveBeenCalledWith('value-1');
+                commonInstance._spy.publicMethod1._func('value-2');
+                expect(commonInstance._spy.publicMethod1._func).toHaveBeenCalledWith('value-2');
+                expect(commonInstance._spy.publicMethod1._func).toHaveBeenCalledTimes(2);
 
-            commonInstance['protectedProperty1'] = 'new-value-1';
-            commonInstance['protectedProperty1'] = 'new-value-2';
-            expect(commonInstance['protectedProperty1']).toBe('new-value-2');
+                (commonInstance._spy as any).protectedMethod1._func('value-1');
+                expect((commonInstance._spy as any).protectedMethod1._func).toHaveBeenCalledWith('value-1');
+                (commonInstance._spy as any).protectedMethod1._func('value-2');
+                expect((commonInstance._spy as any).protectedMethod1._func).toHaveBeenCalledWith('value-2');
+                expect((commonInstance._spy as any).protectedMethod1._func).toHaveBeenCalledTimes(2);
 
-            commonInstance['privateProperty1'] = 'new-value-1';
-            commonInstance['privateProperty1'] = 'new-value-2';
-            expect(commonInstance['privateProperty1']).toBe('new-value-2');
+                (commonInstance._spy as any).privateMethod1._func('value-1');
+                expect((commonInstance._spy as any).privateMethod1._func).toHaveBeenCalledWith('value-1');
+                (commonInstance._spy as any).privateMethod1._func('value-2');
+                expect((commonInstance._spy as any).privateMethod1._func).toHaveBeenCalledWith('value-2');
+                expect((commonInstance._spy as any).privateMethod1._func).toHaveBeenCalledTimes(2);
+            });
 
-            commonInstance['nonExistProperty'] = 'new-value-1';
-            commonInstance['nonExistProperty'] = 'new-value-2';
-            expect(commonInstance['nonExistProperty']).toBe('new-value-2');
-        });
+            it('should register calls on each spy when calls are made after the spys are inspected', () => {
+                expect(commonInstance.publicMethod1).not.toHaveBeenCalled();
+                commonInstance.publicMethod1('value-1');
+                expect(commonInstance.publicMethod1).toHaveBeenCalledWith('value-1');
+                commonInstance.publicMethod1('value-2');
+                expect(commonInstance.publicMethod1).toHaveBeenCalledWith('value-2');
+                expect(commonInstance.publicMethod1).toHaveBeenCalledTimes(2);
 
-        it('should ignore the first direct modification on properties with setters', () => {
-            commonInstance.publicSetterProperty1 = 'new-value';
-            expect(commonInstance.publicSetterProperty1).toBeUndefined();
-            commonInstance.publicGetterSetterProperty1 = 'new-value';
-            expect(commonInstance.publicGetterSetterProperty1).toBeUndefined();
+                expect((commonInstance as any).protectedMethod1).not.toHaveBeenCalled();
+                (commonInstance as any).protectedMethod1('value-1');
+                expect((commonInstance as any).protectedMethod1).toHaveBeenCalledWith('value-1');
+                (commonInstance as any).protectedMethod1('value-2');
+                expect((commonInstance as any).protectedMethod1).toHaveBeenCalledWith('value-2');
+                expect((commonInstance as any).protectedMethod1).toHaveBeenCalledTimes(2);
 
-            commonInstance['protectedSetterProperty1'] = 'new-value';
-            expect(commonInstance['protectedSetterProperty1']).toBeUndefined();
-            commonInstance['protectedGetterSetterProperty1'] = 'new-value';
-            expect(commonInstance['protectedGetterSetterProperty1']).toBeUndefined();
+                expect((commonInstance as any).privateMethod1).not.toHaveBeenCalled();
+                (commonInstance as any).privateMethod1('value-1');
+                expect((commonInstance as any).privateMethod1).toHaveBeenCalledWith('value-1');
+                (commonInstance as any).privateMethod1('value-2');
+                expect((commonInstance as any).privateMethod1).toHaveBeenCalledWith('value-2');
+                expect((commonInstance as any).privateMethod1).toHaveBeenCalledTimes(2);
+            });
 
-            commonInstance['privateSetterProperty1'] = 'new-value';
-            expect(commonInstance['privateSetterProperty1']).toBeUndefined();
-            commonInstance['privateGetterSetterProperty1'] = 'new-value';
-            expect(commonInstance['privateGetterSetterProperty1']).toBeUndefined();
-        });
+            it('should allow spies to be setup before their first calls', () => {
+                (commonInstance.publicMethod1 as jasmine.Spy).and.returnValue(999);
+                expect(commonInstance.publicMethod1('whatever')).toBe(999);
+                expect(commonInstance.publicMethod1('whatever')).toBe(999);
 
-        it('should ignore all direct modifications on properties with setters', () => {
-            commonInstance.publicSetterProperty1 = 'new-value-1';
-            commonInstance.publicSetterProperty1 = 'new-value-2';
-            expect(commonInstance.publicSetterProperty1).toBeUndefined();
-            commonInstance.publicGetterSetterProperty1 = 'new-value-1';
-            commonInstance.publicGetterSetterProperty1 = 'new-value-2';
-            expect(commonInstance.publicGetterSetterProperty1).toBeUndefined();
+                ((commonInstance as any).protectedMethod1 as jasmine.Spy).and.returnValue(999);
+                expect((commonInstance as any).protectedMethod1('whatever')).toBe(999);
+                expect((commonInstance as any).protectedMethod1('whatever')).toBe(999);
 
-            commonInstance['protectedSetterProperty1'] = 'new-value-1';
-            commonInstance['protectedSetterProperty1'] = 'new-value-2';
-            expect(commonInstance['protectedSetterProperty1']).toBeUndefined();
-            commonInstance['protectedGetterSetterProperty1'] = 'new-value-1';
-            commonInstance['protectedGetterSetterProperty1'] = 'new-value-2';
-            expect(commonInstance['protectedGetterSetterProperty1']).toBeUndefined();
+                ((commonInstance as any).privateMethod1 as jasmine.Spy).and.returnValue(999);
+                expect((commonInstance as any).privateMethod1('whatever')).toBe(999);
+                expect((commonInstance as any).privateMethod1('whatever')).toBe(999);
+            });
 
-            commonInstance['privateSetterProperty1'] = 'new-value-1';
-            commonInstance['privateSetterProperty1'] = 'new-value-2';
-            expect(commonInstance['privateSetterProperty1']).toBeUndefined();
-            commonInstance['privateGetterSetterProperty1'] = 'new-value-1';
-            commonInstance['privateGetterSetterProperty1'] = 'new-value-2';
-            expect(commonInstance['privateGetterSetterProperty1']).toBeUndefined();
-        });
+            it('should allow spies to be setup through spyFacade before their first calls', () => {
+                commonInstance._spy.publicMethod1._func.and.returnValue(999);
+                expect(commonInstance.publicMethod1('whatever')).toBe(999);
+                expect(commonInstance.publicMethod1('whatever')).toBe(999);
 
-        it('should throw for modifications on properties with only getters', () => {
-            expect(() => (commonInstance as any).publicGetterProperty1 = 'new-value').toThrow();
-            expect(() => (commonInstance as any).protectedGetterProperty1 = 'new-value').toThrow();
-            expect(() => (commonInstance as any).privateGetterProperty1 = 'new-value').toThrow();
-        });
+                (commonInstance._spy as any).protectedMethod1._func.and.returnValue(999);
+                expect((commonInstance as any).protectedMethod1('whatever')).toBe(999);
+                expect((commonInstance as any).protectedMethod1('whatever')).toBe(999);
 
-        it('should spy getters before they are used', () => {
-            expect(commonInstance._spy.publicGetterProperty1._get).not.toHaveBeenCalled();
-            expect(commonInstance._spy.publicGetterSetterProperty1._get).not.toHaveBeenCalled();
+                (commonInstance._spy as any).privateMethod1._func.and.returnValue(999);
+                expect((commonInstance as any).privateMethod1('whatever')).toBe(999);
+                expect((commonInstance as any).privateMethod1('whatever')).toBe(999);
+            });
 
-            expect(commonInstance._spy['protectedGetterProperty1']._get).not.toHaveBeenCalled();
-            expect(commonInstance._spy['protectedGetterSetterProperty1']._get).not.toHaveBeenCalled();
+            it('should allow spies to be setup after their first calls', () => {
+                commonInstance.publicMethod1('whatever');
+                (commonInstance.publicMethod1 as jasmine.Spy).and.returnValue(999);
+                expect(commonInstance.publicMethod1('whatever')).toBe(999);
+                expect(commonInstance.publicMethod1('whatever')).toBe(999);
 
-            expect(commonInstance._spy['privateGetterProperty1']._get).not.toHaveBeenCalled();
-            expect(commonInstance._spy['privateGetterSetterProperty1']._get).not.toHaveBeenCalled();
-        });
+                (commonInstance as any).protectedMethod1('whatever');
+                ((commonInstance as any).protectedMethod1 as jasmine.Spy).and.returnValue(999);
+                expect((commonInstance as any).protectedMethod1('whatever')).toBe(999);
+                expect((commonInstance as any).protectedMethod1('whatever')).toBe(999);
 
-        it('should spy setters before they are used', () => {
-            expect(commonInstance._spy.publicSetterProperty1._set).not.toHaveBeenCalled();
-            expect(commonInstance._spy.publicGetterSetterProperty1._set).not.toHaveBeenCalled();
+                (commonInstance as any).privateMethod1('whatever');
+                ((commonInstance as any).privateMethod1 as jasmine.Spy).and.returnValue(999);
+                expect((commonInstance as any).privateMethod1('whatever')).toBe(999);
+                expect((commonInstance as any).privateMethod1('whatever')).toBe(999);
+            });
 
-            expect(commonInstance._spy['protectedSetterProperty1']._set).not.toHaveBeenCalled();
-            expect(commonInstance._spy['protectedGetterSetterProperty1']._set).not.toHaveBeenCalled();
+            it('should allow spies to be setup through spyFacade after their first calls', () => {
+                commonInstance.publicMethod1('whatever');
+                commonInstance._spy.publicMethod1._func.and.returnValue(999);
+                expect(commonInstance.publicMethod1('whatever')).toBe(999);
+                expect(commonInstance.publicMethod1('whatever')).toBe(999);
 
-            expect(commonInstance._spy['privateSetterProperty1']._set).not.toHaveBeenCalled();
-            expect(commonInstance._spy['privateGetterSetterProperty1']._set).not.toHaveBeenCalled();
-        });
+                (commonInstance as any).protectedMethod1('whatever');
+                (commonInstance._spy as any).protectedMethod1._func.and.returnValue(999);
+                expect((commonInstance as any).protectedMethod1('whatever')).toBe(999);
+                expect((commonInstance as any).protectedMethod1('whatever')).toBe(999);
 
-        it('should record calls on getters', () => {
-            let temp1 = commonInstance.publicGetterProperty1;
-            temp1 = commonInstance.publicGetterSetterProperty1;
+                (commonInstance as any).privateMethod1('whatever');
+                (commonInstance._spy as any).privateMethod1._func.and.returnValue(999);
+                expect((commonInstance as any).privateMethod1('whatever')).toBe(999);
+                expect((commonInstance as any).privateMethod1('whatever')).toBe(999);
+            });
 
-            expect(commonInstance._spy.publicGetterProperty1._get).toHaveBeenCalled();
-            expect(commonInstance._spy.publicGetterSetterProperty1._get).toHaveBeenCalled();
+            it('should allow spies to be added with non-exist names', () => {
+                (commonInstance as any).nonExistMethod = jasmine.createSpy('newSpy');
+                (commonInstance as any).nonExistMethod('value-1');
+                expect((commonInstance as any).nonExistMethod).toHaveBeenCalledWith('value-1');
+            });
 
-            temp1 = commonInstance.publicGetterProperty1;
-            temp1 = commonInstance.publicGetterSetterProperty1;
+            it('should not allow spies to be replaced before their first calls', () => {
+                let newSpy = jasmine.createSpy('newSpy')
+                expect(() => commonInstance.publicMethod1 = newSpy).toThrowError();
 
-            expect(commonInstance._spy.publicGetterSetterProperty1._get).toHaveBeenCalledTimes(2);
-            expect(commonInstance._spy.publicGetterProperty1._get).toHaveBeenCalledTimes(2);
-        });
+                newSpy = jasmine.createSpy('newSpy')
+                expect(() => (commonInstance as any).protectedMethod1 = newSpy).toThrowError();
 
-        it('should record calls on setters', () => {
-            commonInstance.publicSetterProperty1 = 'new-value';
-            commonInstance.publicGetterSetterProperty1 = 'new-value';
-            expect(commonInstance._spy.publicSetterProperty1._set).toHaveBeenCalledWith('new-value');
-            expect(commonInstance._spy.publicGetterSetterProperty1._set).toHaveBeenCalledWith('new-value');
-            commonInstance.publicSetterProperty1 = 'new-value';
-            commonInstance.publicGetterSetterProperty1 = 'new-value';
-            expect(commonInstance._spy.publicSetterProperty1._set).toHaveBeenCalledTimes(2);
-            expect(commonInstance._spy.publicGetterSetterProperty1._set).toHaveBeenCalledTimes(2);
+                newSpy = jasmine.createSpy('newSpy')
+                expect(() => (commonInstance as any).privateMethod1 = newSpy).toThrowError();
+            });
 
-            commonInstance['protectedSetterProperty1'] = 'new-value';
-            commonInstance['protectedGetterSetterProperty1'] = 'new-value';
-            expect(commonInstance._spy['protectedSetterProperty1']._set).toHaveBeenCalledWith('new-value');
-            expect(commonInstance._spy['protectedGetterSetterProperty1']._set).toHaveBeenCalledWith('new-value');
-            commonInstance['protectedSetterProperty1'] = 'new-value';
-            commonInstance['protectedGetterSetterProperty1'] = 'new-value';
-            expect(commonInstance._spy['protectedSetterProperty1']._set).toHaveBeenCalledTimes(2);
-            expect(commonInstance._spy['protectedGetterSetterProperty1']._set).toHaveBeenCalledTimes(2);
+            it('should not allow spies to be replaced after their calls', () => {
+                commonInstance.publicMethod1('whatever');
+                expect(() => commonInstance.publicMethod1 = jasmine.createSpy('newSpy')).toThrowError();
 
-            commonInstance['privateSetterProperty1'] = 'new-value';
-            commonInstance['privateGetterSetterProperty1'] = 'new-value';
-            expect(commonInstance._spy['privateSetterProperty1']._set).toHaveBeenCalledWith('new-value');
-            expect(commonInstance._spy['privateGetterSetterProperty1']._set).toHaveBeenCalledWith('new-value');
-            commonInstance['privateSetterProperty1'] = 'new-value';
-            commonInstance['privateGetterSetterProperty1'] = 'new-value';
-            expect(commonInstance._spy['privateSetterProperty1']._set).toHaveBeenCalledTimes(2);
-            expect(commonInstance._spy['privateGetterSetterProperty1']._set).toHaveBeenCalledTimes(2);
-        });
+                (commonInstance as any).protectedMethod1('whatever');
+                expect(() => (commonInstance as any).privateMethod1 = jasmine.createSpy('newSpy')).toThrowError();
 
-        it('should modify results from getters before they are used', () => {
-            commonInstance._spy.publicGetterProperty1._get.and.returnValue('new-value-1');
-            commonInstance._spy.publicGetterSetterProperty1._get.and.returnValue('new-value-1');
-            expect(commonInstance.publicGetterProperty1).toBe('new-value-1');
-            expect(commonInstance.publicGetterSetterProperty1).toBe('new-value-1');
+                (commonInstance as any).privateMethod1('whatever');
+                expect(() => (commonInstance as any).privateMethod1 = jasmine.createSpy('newSpy')).toThrowError();
+            });
 
-            commonInstance._spy['protectedGetterProperty1']._get.and.returnValue('new-value-1');
-            commonInstance._spy['protectedGetterSetterProperty1']._get.and.returnValue('new-value-1');
-            expect(commonInstance['protectedGetterProperty1']).toBe('new-value-1');
-            expect(commonInstance['protectedGetterSetterProperty1']).toBe('new-value-1');
+            it('should not allow spies to be replaced after they are accessed from spyFacade', () => {
+                expect(commonInstance._spy.publicMethod1._func).not.toHaveBeenCalled();
+                expect(() => commonInstance.publicMethod1 = jasmine.createSpy('newSpy')).toThrowError();
 
-            commonInstance._spy['privateGetterProperty1']._get.and.returnValue('new-value-1');
-            commonInstance._spy['privateGetterSetterProperty1']._get.and.returnValue('new-value-1');
-            expect(commonInstance['privateGetterProperty1']).toBe('new-value-1');
-            expect(commonInstance['privateGetterSetterProperty1']).toBe('new-value-1');
-        });
+                expect((commonInstance._spy as any).protectedMethod1._func).not.toHaveBeenCalled();
+                expect(() => (commonInstance as any).privateMethod1 = jasmine.createSpy('newSpy')).toThrowError();
 
-        it('should modify results from getters after they are used', () => {
-            let temp1 = commonInstance.publicGetterProperty1;
-            temp1 = commonInstance.publicGetterSetterProperty1;
-            commonInstance._spy.publicGetterProperty1._get.and.returnValue('new-value-1');
-            commonInstance._spy.publicGetterSetterProperty1._get.and.returnValue('new-value-1');
-            expect(commonInstance.publicGetterProperty1).toBe('new-value-1');
-            expect(commonInstance.publicGetterSetterProperty1).toBe('new-value-1');
+                expect((commonInstance._spy as any).privateMethod1._func).not.toHaveBeenCalled();
+                expect(() => (commonInstance as any).privateMethod1 = jasmine.createSpy('newSpy')).toThrowError();
+            });
 
-            temp1 = commonInstance['protectedGetterProperty1'];
-            temp1 = commonInstance['protectedGetterSetterProperty1'];
-            commonInstance._spy['protectedGetterProperty1']._get.and.returnValue('new-value-1');
-            commonInstance._spy['protectedGetterSetterProperty1']._get.and.returnValue('new-value-1');
-            expect(commonInstance['protectedGetterProperty1']).toBe('new-value-1');
-            expect(commonInstance['protectedGetterSetterProperty1']).toBe('new-value-1');
+            it('should not allow spiedMembers to be replaced via spyFacade', () => {
+                expect(commonInstance._spy.publicMethod1._func).not.toHaveBeenCalled();
+                expect(() => commonInstance._spy.publicMethod1 = {}).toThrowError();
 
-            temp1 = commonInstance['privateGetterProperty1'];
-            temp1 = commonInstance['privateGetterSetterProperty1'];
-            commonInstance._spy['privateGetterProperty1']._get.and.returnValue('new-value-1');
-            commonInstance._spy['privateGetterSetterProperty1']._get.and.returnValue('new-value-1');
-            expect(commonInstance['privateGetterProperty1']).toBe('new-value-1');
-            expect(commonInstance['privateGetterSetterProperty1']).toBe('new-value-1');
-        });
+                expect((commonInstance._spy as any).protectedMethod1._func).not.toHaveBeenCalled();
+                expect(() => (commonInstance as any)._spy.privateMethod1 = {}).toThrowError();
 
-        it('should re-modify results from getters', () => {
-            commonInstance._spy.publicGetterProperty1._get.and.returnValue('new-value-1');
-            commonInstance._spy.publicGetterSetterProperty1._get.and.returnValue('new-value-1');
-            expect(commonInstance.publicGetterProperty1).toBe('new-value-1');
-            expect(commonInstance.publicGetterSetterProperty1).toBe('new-value-1');
-            commonInstance._spy.publicGetterProperty1._get.and.returnValue('new-value-2');
-            commonInstance._spy.publicGetterSetterProperty1._get.and.returnValue('new-value-2');
-            expect(commonInstance.publicGetterProperty1).toBe('new-value-2');
-            expect(commonInstance.publicGetterSetterProperty1).toBe('new-value-2');
+                expect((commonInstance._spy as any).privateMethod1._func).not.toHaveBeenCalled();
+                expect(() => (commonInstance as any)._spy.privateMethod1 = {}).toThrowError();
+            });
 
-            commonInstance._spy['protectedGetterProperty1']._get.and.returnValue('new-value-1');
-            commonInstance._spy['protectedGetterSetterProperty1']._get.and.returnValue('new-value-1');
-            expect(commonInstance['protectedGetterProperty1']).toBe('new-value-1');
-            expect(commonInstance['protectedGetterSetterProperty1']).toBe('new-value-1');
-            commonInstance._spy['protectedGetterProperty1']._get.and.returnValue('new-value-2');
-            commonInstance._spy['protectedGetterSetterProperty1']._get.and.returnValue('new-value-2');
-            expect(commonInstance['protectedGetterProperty1']).toBe('new-value-2');
-            expect(commonInstance['protectedGetterSetterProperty1']).toBe('new-value-2');
+            it('should not allow reading _get/_set on functions', () => {
+                expect(() => commonInstance._spy.publicMethod1._get).toThrow();
+                expect(() => commonInstance._spy.publicMethod1._set).toThrow();
 
-            commonInstance._spy['privateGetterProperty1']._get.and.returnValue('new-value-1');
-            commonInstance._spy['privateGetterSetterProperty1']._get.and.returnValue('new-value-1');
-            expect(commonInstance['privateGetterProperty1']).toBe('new-value-1');
-            expect(commonInstance['privateGetterSetterProperty1']).toBe('new-value-1');
-            commonInstance._spy['privateGetterProperty1']._get.and.returnValue('new-value-2');
-            commonInstance._spy['privateGetterSetterProperty1']._get.and.returnValue('new-value-2');
-            expect(commonInstance['privateGetterProperty1']).toBe('new-value-2');
-            expect(commonInstance['privateGetterSetterProperty1']).toBe('new-value-2');
-        });
+                expect(() => commonInstance._spy['protectedMethod1']._get).toThrow();
+                expect(() => commonInstance._spy['protectedMethod1']._set).toThrow();
 
-        it('should return spy for all functions', () => {
-            expect(commonInstance.publicMethod1).not.toHaveBeenCalled();
-            expect(commonInstance.publicMethod1).not.toHaveBeenCalled();
-            expect((commonInstance as any).privateMethod).not.toHaveBeenCalled();
-            expect((commonInstance as any).privateMethod).not.toHaveBeenCalled();
-        });
+                expect(() => commonInstance._spy['privateMethod1']._get).toThrow();
+                expect(() => commonInstance._spy['privateMethod1']._set).toThrow();
+            });
 
-        it('should register calls on each spy', () => {
-            commonInstance.publicMethod1('value-1');
-            expect(commonInstance.publicMethod1).toHaveBeenCalledWith('value-1');
-            commonInstance.publicMethod1('value-2');
-            expect(commonInstance.publicMethod1).toHaveBeenCalledWith('value-2');
-            expect(commonInstance.publicMethod1).toHaveBeenCalledTimes(2);
+            it('should not allow writing _get/_set on functions', () => {
+                expect(() => commonInstance._spy.publicMethod1._get = jasmine.createSpy('whatever')).toThrow();
+                expect(() => commonInstance._spy.publicMethod1._set = jasmine.createSpy('whatever')).toThrow();
 
-            (commonInstance as any).privateMethod('value-1');
-            expect((commonInstance as any).privateMethod).toHaveBeenCalledWith('value-1');
-            (commonInstance as any).privateMethod('value-2');
-            expect((commonInstance as any).privateMethod).toHaveBeenCalledWith('value-2');
-            expect((commonInstance as any).privateMethod).toHaveBeenCalledTimes(2);
+                expect(() => commonInstance._spy['protectedMethod1']._get = jasmine.createSpy('whatever')).toThrow();
+                expect(() => commonInstance._spy['protectedMethod1']._set = jasmine.createSpy('whatever')).toThrow();
 
-            commonInstance.publicGetterSetterProperty1 = 'value-1';
-            expect(commonInstance._spy.publicGetterSetterProperty1._set).toHaveBeenCalledWith('value-1');
-            commonInstance.publicGetterSetterProperty1 = 'value-2';
-            expect(commonInstance._spy.publicGetterSetterProperty1._set).toHaveBeenCalledWith('value-2');
-            expect(commonInstance._spy.publicGetterSetterProperty1._set).toHaveBeenCalledTimes(2);
-
-            const whatever1 = commonInstance.publicGetterSetterProperty1;
-            expect(commonInstance._spy.publicGetterSetterProperty1._get).toHaveBeenCalled();
-            const whatever2 = commonInstance.publicGetterSetterProperty1;
-            expect(commonInstance._spy.publicGetterSetterProperty1._get).toHaveBeenCalledTimes(2);
-        });
-
-        it('should allow spy setup before its first call', () => {
-            (commonInstance.publicMethod1 as jasmine.Spy).and.returnValue(999);
-            expect(commonInstance.publicMethod1('whatever')).toBe(999);
-            expect(commonInstance.publicMethod1('whatever')).toBe(999);
-
-            ((commonInstance as any).privateMethod as jasmine.Spy).and.returnValue(999);
-            expect((commonInstance as any).privateMethod('whatever')).toBe(999);
-            expect((commonInstance as any).privateMethod('whatever')).toBe(999);
-        });
-
-        it('should allow spy setup after its first call', () => {
-            commonInstance.publicMethod1('whatever');
-
-            (commonInstance.publicMethod1 as jasmine.Spy).and.returnValue(111);
-            expect(commonInstance.publicMethod1('whatever')).toBe(111);
-            (commonInstance.publicMethod1 as jasmine.Spy).and.returnValue(999);
-            expect(commonInstance.publicMethod1('whatever')).toBe(999);
-
-            (commonInstance as any).privateMethod('whatever');
-
-            ((commonInstance as any).privateMethod as jasmine.Spy).and.returnValue(111);
-            expect((commonInstance as any).privateMethod('whatever')).toBe(111);
-            ((commonInstance as any).privateMethod as jasmine.Spy).and.returnValue(999);
-            expect((commonInstance as any).privateMethod('whatever')).toBe(999);
-        });
-
-        it('should allow spy to be added with non-exist names', () => {
-            (commonInstance as any).nonExistMethod = jasmine.createSpy('newSpy');
-            (commonInstance as any).nonExistMethod('value-1');
-            expect((commonInstance as any).nonExistMethod).toHaveBeenCalledWith('value-1');
-        });
-
-        it('should allow spy to be replaced before its first call', () => {
-            const newSpy1 = jasmine.createSpy('newSpy')
-            expect(() => commonInstance.publicMethod1 = newSpy1).not.toThrowError();
-            commonInstance.publicMethod1('value-1');
-
-            expect(newSpy1).toHaveBeenCalledWith('value-1');
-
-            const newSpy2 = jasmine.createSpy('newSpy')
-            expect(() => (commonInstance as any).privateMethod = newSpy2).not.toThrowError();
-            (commonInstance as any).privateMethod('value-1');
-
-            expect(newSpy2).toHaveBeenCalledWith('value-1');
-        });
-
-        it('should allow spy to be replaced after its first call', () => {
-            commonInstance.publicMethod1('whatever');
-            const newSpy1 = jasmine.createSpy('newSpy')
-            expect(() => commonInstance.publicMethod1 = newSpy1).not.toThrowError();
-            commonInstance.publicMethod1('value-1');
-
-            expect(newSpy1).toHaveBeenCalledWith('value-1');
-
-            (commonInstance as any).privateMethod('whatever');
-            const newSpy2 = jasmine.createSpy('newSpy')
-            expect(() => (commonInstance as any).privateMethod = newSpy2).not.toThrowError();
-            (commonInstance as any).privateMethod('value-1');
-
-            expect(newSpy2).toHaveBeenCalledWith('value-1');
-        });
-
-        it('should throw when _spy facade is modified', () => {
-            expect(() => commonInstance._spy = 42 as any).toThrow();
-            expect(() => commonInstance._spy.publicGetterSetterProperty1 = {} as any).toThrow();
+                expect(() => commonInstance._spy['privateMethod1']._get = jasmine.createSpy('whatever')).toThrow();
+                expect(() => commonInstance._spy['privateMethod1']._set = jasmine.createSpy('whatever')).toThrow();
+            });
         });
     }
 });

--- a/src/lib/index.spec.ts
+++ b/src/lib/index.spec.ts
@@ -6,91 +6,161 @@
 
 import { MockFactory, Mock } from './index';
 
-interface IClass1 {
+interface IBaseClass {
     publicProperty1: string;
     publicProperty2: string;
-    readonly gettableProperty1: string;
-    getSetProperty1: string;
-    settableProperty1: string;
-    publicMethod(arg1: string): number;
+    readonly publicGetterProperty1: string;
+    publicSetterProperty1: string;
+    publicGetterSetterProperty1: string;
+    publicMethod1(arg1: string): number;
 }
 
-class Class1 implements IClass1 {
+interface ISubClass extends IBaseClass {
+    subPublicMethod1(arg1: string): number;
+}
+
+class BaseClass implements IBaseClass {
+    public publicProperty1: string;
+    protected protectedProperty1: string;
     private privateProperty1: string;
-    private privateProperty2 = 'value-a1';
 
-    public get gettableProperty1() {
-        return 'value-c1';
+    public publicProperty2 = 'value-a1';
+    protected protectedProperty2: 'value-b1'
+    private privateProperty2 = 'value-c1';
+
+    public get publicGetterProperty1() { return 'value-d1'; }
+    protected get protectedGetterProperty1() { return 'value-f1'; }
+    private get privateGetterProperty1() { return 'value-f1'; }
+
+    public set publicSetterProperty1(value: string) { }
+    protected set protectedSetterProperty1(value: string) { }
+    private set privateSetterProperty1(value: string) { }
+
+    public get publicGetterSetterProperty1() { return 'value-e1'; }
+    protected get protectedGetterSetterProperty1() { return 'value-g1'; }
+    private get privateGetterSetterProperty1() { return 'value-g1'; }
+
+    public set publicGetterSetterProperty1(value: string) { }
+    protected set protectedGetterSetterProperty1(value: string) { }
+    private set privateGetterSetterProperty1(value: string) { }
+
+    public publicMethod1(arg1: string): number {
+        return 2;
     }
 
-    public set settableProperty1(value: string) {
-        // noop
-    }
-
-    public get getSetProperty1() {
-        return 'value-d1';
-    }
-
-    public set getSetProperty1(value: string) {
-        // noop
-    }
-
-    public publicMethod(arg1: string): number {
-        return 42;
+    protected protectedMethod(arg1: string): number {
+        return 3;
     }
 
     private privateMethod(arg1: string): number {
-        return 123;
+        return 5;
     }
-
-    constructor(
-        public publicProperty1: string,
-        public publicProperty2 = 'value-b1',
-    ) {}
 }
 
-class Class2 extends Class1 { }
+class SubClass extends BaseClass implements ISubClass {
+    public subPublicMethod1(arg1: string): number {
+        return 7;
+    }
+}
 
-describe('MockFactory', () => {
-    let mockInstance: Mock<Class1 | Class2 | IClass1>;
+function createMockFromBaseClass(): Mock<BaseClass> {
+    return MockFactory.create(BaseClass);
+}
 
-    describe('mocking a class using a typescript class', () => {
+function createMockFromSubClass(): Mock<SubClass> {
+    return MockFactory.create(SubClass);
+}
 
-        beforeEach(() => {
-            mockInstance = MockFactory.create(Class1);
-        });
+function createMockFromBaseIntance(): Mock<IBaseClass> {
+    const instance = new BaseClass();
+    return MockFactory.create(instance);
+}
 
-        runSharedSpecs();
+function createMockFromSubInstance(): Mock<ISubClass> {
+    const instance = new SubClass();
+    return MockFactory.create(instance);
+}
+
+function createMockWindow(): Mock<Window> {
+    return MockFactory.create(window);
+}
+
+function createMockLocation(): Mock<Location> {
+    return MockFactory.create(location);
+}
+
+function createMockLocalStorage(): Mock<Storage> {
+    return MockFactory.create(localStorage);
+}
+
+describe('Creating mocks', () => {
+    it('should create a mock from a base class', () => {
+        expect(() => createMockFromBaseClass()).not.toThrow()
     });
 
-    describe('mocking an inherited class using an inherited typescript class', () => {
-
-        beforeEach(() => {
-            mockInstance = MockFactory.create(Class2);
-        });
-
-        runSharedSpecs();
+    it('should create a mock from a sub class', () => {
+        expect(() => createMockFromSubClass()).not.toThrow()
     });
 
-    describe('mocking an interface using an instance', () => {
-        beforeEach(() => {
-            const realInstance = new Class1('value-1');
-            mockInstance = MockFactory.create(realInstance);
-        });
-
-        runSharedSpecs();
+    it('should create a mock from a base instance', () => {
+        expect(() => createMockFromBaseIntance()).not.toThrow()
     });
 
-    describe('mocking an inherited interface using an inherited instance', () => {
-        beforeEach(() => {
-            const realInstance = new Class2('value-1');
-            mockInstance = MockFactory.create(realInstance);
-        });
-
-        runSharedSpecs();
+    it('should create a mock from a sub instance', () => {
+        expect(() => createMockFromSubInstance()).not.toThrow()
     });
 
-    describe('mocking window object', () => {
+    it('should create a mock from the window object', () => {
+        expect(() => createMockWindow()).not.toThrow()
+    });
+
+    it('should create a mock from the location object', () => {
+        expect(() => createMockLocation()).not.toThrow()
+    });
+
+    it('should create a mock from the localStorage object', () => {
+        expect(() => createMockLocalStorage()).not.toThrow()
+    });
+});
+
+describe('Using mocks', () => {
+    let commonInstance: Mock<BaseClass | SubClass | IBaseClass | ISubClass>;
+
+    describe('using a mock created from a base class', () => {
+
+        beforeEach(() => {
+            commonInstance = createMockFromBaseClass();
+        });
+
+        runCommonSpecs();
+    });
+
+    describe('using a mock created from a sub class', () => {
+
+        beforeEach(() => {
+            commonInstance = createMockFromSubClass();
+        });
+
+        runCommonSpecs();
+    });
+
+    describe('using a mock created from an instance of a base class', () => {
+        beforeEach(() => {
+            commonInstance = createMockFromBaseIntance();
+        });
+
+        runCommonSpecs();
+    });
+
+    describe('using a mock created from an instance of a sub class', () => {
+        beforeEach(() => {
+            commonInstance = createMockFromSubInstance();
+        });
+
+        runCommonSpecs();
+    });
+
+    describe('using a mock created from the window object', () => {
         let mockWindow: Mock<Window>;
         beforeEach(() => {
             mockWindow = MockFactory.create(window);
@@ -115,7 +185,7 @@ describe('MockFactory', () => {
         });
     });
 
-    describe('mocking location object', () => {
+    describe('using a mock created from the location object', () => {
         let mockLocation: Mock<Location>;
         beforeEach(() => {
             mockLocation = MockFactory.create(location);
@@ -132,6 +202,9 @@ describe('MockFactory', () => {
         it('should spy getter on location', () => {
             mockLocation._spy.origin._get.and.returnValue('https://foobar.com');
             expect(mockLocation.origin).toBe('https://foobar.com');
+
+            mockLocation._spy.search._get.and.returnValue('?param=1');
+            expect(mockLocation.search).toBe('?param=1');
         });
 
         it('should spy setter on location', () => {
@@ -140,7 +213,7 @@ describe('MockFactory', () => {
         });
     });
 
-    describe('mocking localStorage object', () => {
+    describe('using a mock created from the localStorage object', () => {
         let mockLocalStorage: Mock<Storage>;
         beforeEach(() => {
             mockLocalStorage = MockFactory.create(localStorage);
@@ -160,146 +233,363 @@ describe('MockFactory', () => {
         });
     });
 
-    function runSharedSpecs() {
-        it('should return undefined for all properties', () => {
-            expect(mockInstance.publicProperty1).toBeUndefined();
-            expect(mockInstance.publicProperty2).toBeUndefined();
-            expect(mockInstance.gettableProperty1).toBeUndefined();
-            expect(mockInstance.getSetProperty1).toBeUndefined();
-            expect((mockInstance as any).privateProperty1).toBeUndefined();
-            expect((mockInstance as any).privateProperty2).toBeUndefined();
-            expect((mockInstance as any).nonExistProperty).toBeUndefined();
+    function runCommonSpecs() {
+        it('should return undefined for all public properties', () => {
+            expect(commonInstance.publicProperty1).toBeUndefined();
+            expect(commonInstance.publicProperty2).toBeUndefined();
+            expect(commonInstance.publicGetterProperty1).toBeUndefined();
+            expect(commonInstance.publicSetterProperty1).toBeUndefined();
+            expect(commonInstance.publicGetterSetterProperty1).toBeUndefined();
+
+            expect(commonInstance['publicProperty1']).toBeUndefined();
+            expect(commonInstance['publicProperty2']).toBeUndefined();
+            expect(commonInstance['publicGetterProperty1']).toBeUndefined();
+            expect(commonInstance['publicSetterProperty1']).toBeUndefined();
+            expect(commonInstance['publicGetterSetterProperty1']).toBeUndefined();
         });
 
-        it('should persist modification for all properties', () => {
-            mockInstance.publicProperty1 = 'new-value-1';
-            expect(mockInstance.publicProperty1).toBe('new-value-1');
-            mockInstance.publicProperty1 = 'new-value-2';
-            expect(mockInstance.publicProperty1).toBe('new-value-2');
-            expect(mockInstance.publicProperty1).toBe('new-value-2');
+        it('should return undefined for all protected properties', () => {
+            expect((commonInstance as any).protectedProperty1).toBeUndefined();
+            expect((commonInstance as any).protectedProperty2).toBeUndefined();
+            expect((commonInstance as any).protectedGetterProperty1).toBeUndefined();
+            expect((commonInstance as any).protectedSetterProperty1).toBeUndefined();
+            expect((commonInstance as any).protectedGetterSetterProperty1).toBeUndefined();
 
-            mockInstance._spy.gettableProperty1._get.and.returnValue('new-value-1');
-            expect(mockInstance.gettableProperty1).toBe('new-value-1');
-            mockInstance._spy.gettableProperty1._get.and.returnValue('new-value-2');
-            expect(mockInstance.gettableProperty1).toBe('new-value-2');
-            expect(mockInstance.gettableProperty1).toBe('new-value-2');
+            expect(commonInstance['protectedProperty1']).toBeUndefined();
+            expect(commonInstance['protectedProperty2']).toBeUndefined();
+            expect(commonInstance['protectedGetterProperty1']).toBeUndefined();
+            expect(commonInstance['protectedSetterProperty1']).toBeUndefined();
+            expect(commonInstance['protectedGetterSetterProperty1']).toBeUndefined();
+        });
 
-            mockInstance._spy.getSetProperty1._get.and.returnValue('new-value-1');
-            expect(mockInstance.getSetProperty1).toBe('new-value-1');
-            mockInstance._spy.getSetProperty1._get.and.returnValue('new-value-2');
-            expect(mockInstance.getSetProperty1).toBe('new-value-2');
-            expect(mockInstance.getSetProperty1).toBe('new-value-2');
+        it('should return undefined for all private properties', () => {
+            expect((commonInstance as any).privateProperty1).toBeUndefined();
+            expect((commonInstance as any).privateProperty2).toBeUndefined();
+            expect((commonInstance as any).privateGetterProperty1).toBeUndefined();
+            expect((commonInstance as any).privateSetterProperty1).toBeUndefined();
+            expect((commonInstance as any).privateGetterSetterProperty1).toBeUndefined();
 
-            (mockInstance as any).privateProperty1 = 'new-value-1';
-            expect((mockInstance as any).privateProperty1).toBe('new-value-1');
-            (mockInstance as any).privateProperty1 = 'new-value-2';
-            expect((mockInstance as any).privateProperty1).toBe('new-value-2');
-            expect((mockInstance as any).privateProperty1).toBe('new-value-2');
+            expect(commonInstance['privateProperty1']).toBeUndefined();
+            expect(commonInstance['privateProperty2']).toBeUndefined();
+            expect(commonInstance['privateGetterProperty1']).toBeUndefined();
+            expect(commonInstance['privateSetterProperty1']).toBeUndefined();
+            expect(commonInstance['privateGetterSetterProperty1']).toBeUndefined();
+        });
 
-            (mockInstance as any).nonExistProperty = 'new-value-1';
-            expect((mockInstance as any).nonExistProperty).toBe('new-value-1');
-            (mockInstance as any).nonExistProperty = 'new-value-2';
-            expect((mockInstance as any).nonExistProperty).toBe('new-value-2');
-            expect((mockInstance as any).nonExistProperty).toBe('new-value-2');
+        it('should return undefined for non-exist properties', () => {
+            expect((commonInstance as any).nonExistProperty).toBeUndefined();
+            expect(commonInstance['nonExistProperty']).toBeUndefined();
+        });
+
+        it('should persist the first modification on properties', () => {
+            commonInstance.publicProperty1 = 'new-value';
+            expect(commonInstance.publicProperty1).toBe('new-value');
+
+            commonInstance['protectedProperty1'] = 'new-value';
+            expect(commonInstance['protectedProperty1']).toBe('new-value');
+
+            commonInstance['privateProperty1'] = 'new-value';
+            expect(commonInstance['privateProperty1']).toBe('new-value');
+
+            commonInstance['nonExistProperty'] = 'new-value';
+            expect(commonInstance['nonExistProperty']).toBe('new-value');
+        });
+
+        it('should persist all modifications on properties', () => {
+            commonInstance.publicProperty1 = 'new-value-1';
+            commonInstance.publicProperty1 = 'new-value-2';
+            expect(commonInstance.publicProperty1).toBe('new-value-2');
+
+            commonInstance['protectedProperty1'] = 'new-value-1';
+            commonInstance['protectedProperty1'] = 'new-value-2';
+            expect(commonInstance['protectedProperty1']).toBe('new-value-2');
+
+            commonInstance['privateProperty1'] = 'new-value-1';
+            commonInstance['privateProperty1'] = 'new-value-2';
+            expect(commonInstance['privateProperty1']).toBe('new-value-2');
+
+            commonInstance['nonExistProperty'] = 'new-value-1';
+            commonInstance['nonExistProperty'] = 'new-value-2';
+            expect(commonInstance['nonExistProperty']).toBe('new-value-2');
+        });
+
+        it('should ignore the first direct modification on properties with setters', () => {
+            commonInstance.publicSetterProperty1 = 'new-value';
+            expect(commonInstance.publicSetterProperty1).toBeUndefined();
+            commonInstance.publicGetterSetterProperty1 = 'new-value';
+            expect(commonInstance.publicGetterSetterProperty1).toBeUndefined();
+
+            commonInstance['protectedSetterProperty1'] = 'new-value';
+            expect(commonInstance['protectedSetterProperty1']).toBeUndefined();
+            commonInstance['protectedGetterSetterProperty1'] = 'new-value';
+            expect(commonInstance['protectedGetterSetterProperty1']).toBeUndefined();
+
+            commonInstance['privateSetterProperty1'] = 'new-value';
+            expect(commonInstance['privateSetterProperty1']).toBeUndefined();
+            commonInstance['privateGetterSetterProperty1'] = 'new-value';
+            expect(commonInstance['privateGetterSetterProperty1']).toBeUndefined();
+        });
+
+        it('should ignore all direct modifications on properties with setters', () => {
+            commonInstance.publicSetterProperty1 = 'new-value-1';
+            commonInstance.publicSetterProperty1 = 'new-value-2';
+            expect(commonInstance.publicSetterProperty1).toBeUndefined();
+            commonInstance.publicGetterSetterProperty1 = 'new-value-1';
+            commonInstance.publicGetterSetterProperty1 = 'new-value-2';
+            expect(commonInstance.publicGetterSetterProperty1).toBeUndefined();
+
+            commonInstance['protectedSetterProperty1'] = 'new-value-1';
+            commonInstance['protectedSetterProperty1'] = 'new-value-2';
+            expect(commonInstance['protectedSetterProperty1']).toBeUndefined();
+            commonInstance['protectedGetterSetterProperty1'] = 'new-value-1';
+            commonInstance['protectedGetterSetterProperty1'] = 'new-value-2';
+            expect(commonInstance['protectedGetterSetterProperty1']).toBeUndefined();
+
+            commonInstance['privateSetterProperty1'] = 'new-value-1';
+            commonInstance['privateSetterProperty1'] = 'new-value-2';
+            expect(commonInstance['privateSetterProperty1']).toBeUndefined();
+            commonInstance['privateGetterSetterProperty1'] = 'new-value-1';
+            commonInstance['privateGetterSetterProperty1'] = 'new-value-2';
+            expect(commonInstance['privateGetterSetterProperty1']).toBeUndefined();
+        });
+
+        it('should throw for modifications on properties with only getters', () => {
+            expect(() => (commonInstance as any).publicGetterProperty1 = 'new-value').toThrow();
+            expect(() => (commonInstance as any).protectedGetterProperty1 = 'new-value').toThrow();
+            expect(() => (commonInstance as any).privateGetterProperty1 = 'new-value').toThrow();
+        });
+
+        it('should spy getters before they are used', () => {
+            expect(commonInstance._spy.publicGetterProperty1._get).not.toHaveBeenCalled();
+            expect(commonInstance._spy.publicGetterSetterProperty1._get).not.toHaveBeenCalled();
+
+            expect(commonInstance._spy['protectedGetterProperty1']._get).not.toHaveBeenCalled();
+            expect(commonInstance._spy['protectedGetterSetterProperty1']._get).not.toHaveBeenCalled();
+
+            expect(commonInstance._spy['privateGetterProperty1']._get).not.toHaveBeenCalled();
+            expect(commonInstance._spy['privateGetterSetterProperty1']._get).not.toHaveBeenCalled();
+        });
+
+        it('should spy setters before they are used', () => {
+            expect(commonInstance._spy.publicSetterProperty1._set).not.toHaveBeenCalled();
+            expect(commonInstance._spy.publicGetterSetterProperty1._set).not.toHaveBeenCalled();
+
+            expect(commonInstance._spy['protectedSetterProperty1']._set).not.toHaveBeenCalled();
+            expect(commonInstance._spy['protectedGetterSetterProperty1']._set).not.toHaveBeenCalled();
+
+            expect(commonInstance._spy['privateSetterProperty1']._set).not.toHaveBeenCalled();
+            expect(commonInstance._spy['privateGetterSetterProperty1']._set).not.toHaveBeenCalled();
+        });
+
+        it('should record calls on getters', () => {
+            let temp1 = commonInstance.publicGetterProperty1;
+            temp1 = commonInstance.publicGetterSetterProperty1;
+
+            expect(commonInstance._spy.publicGetterProperty1._get).toHaveBeenCalled();
+            expect(commonInstance._spy.publicGetterSetterProperty1._get).toHaveBeenCalled();
+
+            temp1 = commonInstance.publicGetterProperty1;
+            temp1 = commonInstance.publicGetterSetterProperty1;
+
+            expect(commonInstance._spy.publicGetterSetterProperty1._get).toHaveBeenCalledTimes(2);
+            expect(commonInstance._spy.publicGetterProperty1._get).toHaveBeenCalledTimes(2);
+        });
+
+        it('should record calls on setters', () => {
+            commonInstance.publicSetterProperty1 = 'new-value';
+            commonInstance.publicGetterSetterProperty1 = 'new-value';
+            expect(commonInstance._spy.publicSetterProperty1._set).toHaveBeenCalledWith('new-value');
+            expect(commonInstance._spy.publicGetterSetterProperty1._set).toHaveBeenCalledWith('new-value');
+            commonInstance.publicSetterProperty1 = 'new-value';
+            commonInstance.publicGetterSetterProperty1 = 'new-value';
+            expect(commonInstance._spy.publicSetterProperty1._set).toHaveBeenCalledTimes(2);
+            expect(commonInstance._spy.publicGetterSetterProperty1._set).toHaveBeenCalledTimes(2);
+
+            commonInstance['protectedSetterProperty1'] = 'new-value';
+            commonInstance['protectedGetterSetterProperty1'] = 'new-value';
+            expect(commonInstance._spy['protectedSetterProperty1']._set).toHaveBeenCalledWith('new-value');
+            expect(commonInstance._spy['protectedGetterSetterProperty1']._set).toHaveBeenCalledWith('new-value');
+            commonInstance['protectedSetterProperty1'] = 'new-value';
+            commonInstance['protectedGetterSetterProperty1'] = 'new-value';
+            expect(commonInstance._spy['protectedSetterProperty1']._set).toHaveBeenCalledTimes(2);
+            expect(commonInstance._spy['protectedGetterSetterProperty1']._set).toHaveBeenCalledTimes(2);
+
+            commonInstance['privateSetterProperty1'] = 'new-value';
+            commonInstance['privateGetterSetterProperty1'] = 'new-value';
+            expect(commonInstance._spy['privateSetterProperty1']._set).toHaveBeenCalledWith('new-value');
+            expect(commonInstance._spy['privateGetterSetterProperty1']._set).toHaveBeenCalledWith('new-value');
+            commonInstance['privateSetterProperty1'] = 'new-value';
+            commonInstance['privateGetterSetterProperty1'] = 'new-value';
+            expect(commonInstance._spy['privateSetterProperty1']._set).toHaveBeenCalledTimes(2);
+            expect(commonInstance._spy['privateGetterSetterProperty1']._set).toHaveBeenCalledTimes(2);
+        });
+
+        it('should modify results from getters before they are used', () => {
+            commonInstance._spy.publicGetterProperty1._get.and.returnValue('new-value-1');
+            commonInstance._spy.publicGetterSetterProperty1._get.and.returnValue('new-value-1');
+            expect(commonInstance.publicGetterProperty1).toBe('new-value-1');
+            expect(commonInstance.publicGetterSetterProperty1).toBe('new-value-1');
+
+            commonInstance._spy['protectedGetterProperty1']._get.and.returnValue('new-value-1');
+            commonInstance._spy['protectedGetterSetterProperty1']._get.and.returnValue('new-value-1');
+            expect(commonInstance['protectedGetterProperty1']).toBe('new-value-1');
+            expect(commonInstance['protectedGetterSetterProperty1']).toBe('new-value-1');
+
+            commonInstance._spy['privateGetterProperty1']._get.and.returnValue('new-value-1');
+            commonInstance._spy['privateGetterSetterProperty1']._get.and.returnValue('new-value-1');
+            expect(commonInstance['privateGetterProperty1']).toBe('new-value-1');
+            expect(commonInstance['privateGetterSetterProperty1']).toBe('new-value-1');
+        });
+
+        it('should modify results from getters after they are used', () => {
+            let temp1 = commonInstance.publicGetterProperty1;
+            temp1 = commonInstance.publicGetterSetterProperty1;
+            commonInstance._spy.publicGetterProperty1._get.and.returnValue('new-value-1');
+            commonInstance._spy.publicGetterSetterProperty1._get.and.returnValue('new-value-1');
+            expect(commonInstance.publicGetterProperty1).toBe('new-value-1');
+            expect(commonInstance.publicGetterSetterProperty1).toBe('new-value-1');
+
+            temp1 = commonInstance['protectedGetterProperty1'];
+            temp1 = commonInstance['protectedGetterSetterProperty1'];
+            commonInstance._spy['protectedGetterProperty1']._get.and.returnValue('new-value-1');
+            commonInstance._spy['protectedGetterSetterProperty1']._get.and.returnValue('new-value-1');
+            expect(commonInstance['protectedGetterProperty1']).toBe('new-value-1');
+            expect(commonInstance['protectedGetterSetterProperty1']).toBe('new-value-1');
+
+            temp1 = commonInstance['privateGetterProperty1'];
+            temp1 = commonInstance['privateGetterSetterProperty1'];
+            commonInstance._spy['privateGetterProperty1']._get.and.returnValue('new-value-1');
+            commonInstance._spy['privateGetterSetterProperty1']._get.and.returnValue('new-value-1');
+            expect(commonInstance['privateGetterProperty1']).toBe('new-value-1');
+            expect(commonInstance['privateGetterSetterProperty1']).toBe('new-value-1');
+        });
+
+        it('should re-modify results from getters', () => {
+            commonInstance._spy.publicGetterProperty1._get.and.returnValue('new-value-1');
+            commonInstance._spy.publicGetterSetterProperty1._get.and.returnValue('new-value-1');
+            expect(commonInstance.publicGetterProperty1).toBe('new-value-1');
+            expect(commonInstance.publicGetterSetterProperty1).toBe('new-value-1');
+            commonInstance._spy.publicGetterProperty1._get.and.returnValue('new-value-2');
+            commonInstance._spy.publicGetterSetterProperty1._get.and.returnValue('new-value-2');
+            expect(commonInstance.publicGetterProperty1).toBe('new-value-2');
+            expect(commonInstance.publicGetterSetterProperty1).toBe('new-value-2');
+
+            commonInstance._spy['protectedGetterProperty1']._get.and.returnValue('new-value-1');
+            commonInstance._spy['protectedGetterSetterProperty1']._get.and.returnValue('new-value-1');
+            expect(commonInstance['protectedGetterProperty1']).toBe('new-value-1');
+            expect(commonInstance['protectedGetterSetterProperty1']).toBe('new-value-1');
+            commonInstance._spy['protectedGetterProperty1']._get.and.returnValue('new-value-2');
+            commonInstance._spy['protectedGetterSetterProperty1']._get.and.returnValue('new-value-2');
+            expect(commonInstance['protectedGetterProperty1']).toBe('new-value-2');
+            expect(commonInstance['protectedGetterSetterProperty1']).toBe('new-value-2');
+
+            commonInstance._spy['privateGetterProperty1']._get.and.returnValue('new-value-1');
+            commonInstance._spy['privateGetterSetterProperty1']._get.and.returnValue('new-value-1');
+            expect(commonInstance['privateGetterProperty1']).toBe('new-value-1');
+            expect(commonInstance['privateGetterSetterProperty1']).toBe('new-value-1');
+            commonInstance._spy['privateGetterProperty1']._get.and.returnValue('new-value-2');
+            commonInstance._spy['privateGetterSetterProperty1']._get.and.returnValue('new-value-2');
+            expect(commonInstance['privateGetterProperty1']).toBe('new-value-2');
+            expect(commonInstance['privateGetterSetterProperty1']).toBe('new-value-2');
         });
 
         it('should return spy for all functions', () => {
-            expect(mockInstance.publicMethod).not.toHaveBeenCalled();
-            expect(mockInstance.publicMethod).not.toHaveBeenCalled();
-            expect((mockInstance as any).privateMethod).not.toHaveBeenCalled();
-            expect((mockInstance as any).privateMethod).not.toHaveBeenCalled();
+            expect(commonInstance.publicMethod1).not.toHaveBeenCalled();
+            expect(commonInstance.publicMethod1).not.toHaveBeenCalled();
+            expect((commonInstance as any).privateMethod).not.toHaveBeenCalled();
+            expect((commonInstance as any).privateMethod).not.toHaveBeenCalled();
         });
 
         it('should register calls on each spy', () => {
-            mockInstance.publicMethod('value-1');
-            expect(mockInstance.publicMethod).toHaveBeenCalledWith('value-1');
-            mockInstance.publicMethod('value-2');
-            expect(mockInstance.publicMethod).toHaveBeenCalledWith('value-2');
-            expect(mockInstance.publicMethod).toHaveBeenCalledTimes(2);
+            commonInstance.publicMethod1('value-1');
+            expect(commonInstance.publicMethod1).toHaveBeenCalledWith('value-1');
+            commonInstance.publicMethod1('value-2');
+            expect(commonInstance.publicMethod1).toHaveBeenCalledWith('value-2');
+            expect(commonInstance.publicMethod1).toHaveBeenCalledTimes(2);
 
-            (mockInstance as any).privateMethod('value-1');
-            expect((mockInstance as any).privateMethod).toHaveBeenCalledWith('value-1');
-            (mockInstance as any).privateMethod('value-2');
-            expect((mockInstance as any).privateMethod).toHaveBeenCalledWith('value-2');
-            expect((mockInstance as any).privateMethod).toHaveBeenCalledTimes(2);
+            (commonInstance as any).privateMethod('value-1');
+            expect((commonInstance as any).privateMethod).toHaveBeenCalledWith('value-1');
+            (commonInstance as any).privateMethod('value-2');
+            expect((commonInstance as any).privateMethod).toHaveBeenCalledWith('value-2');
+            expect((commonInstance as any).privateMethod).toHaveBeenCalledTimes(2);
 
-            mockInstance.getSetProperty1 = 'value-1';
-            expect(mockInstance._spy.getSetProperty1._set).toHaveBeenCalledWith('value-1');
-            mockInstance.getSetProperty1 = 'value-2';
-            expect(mockInstance._spy.getSetProperty1._set).toHaveBeenCalledWith('value-2');
-            expect(mockInstance._spy.getSetProperty1._set).toHaveBeenCalledTimes(2);
+            commonInstance.publicGetterSetterProperty1 = 'value-1';
+            expect(commonInstance._spy.publicGetterSetterProperty1._set).toHaveBeenCalledWith('value-1');
+            commonInstance.publicGetterSetterProperty1 = 'value-2';
+            expect(commonInstance._spy.publicGetterSetterProperty1._set).toHaveBeenCalledWith('value-2');
+            expect(commonInstance._spy.publicGetterSetterProperty1._set).toHaveBeenCalledTimes(2);
 
-            const whatever1 = mockInstance.getSetProperty1;
-            expect(mockInstance._spy.getSetProperty1._get).toHaveBeenCalled();
-            const whatever2 = mockInstance.getSetProperty1;
-            expect(mockInstance._spy.getSetProperty1._get).toHaveBeenCalledTimes(2);
+            const whatever1 = commonInstance.publicGetterSetterProperty1;
+            expect(commonInstance._spy.publicGetterSetterProperty1._get).toHaveBeenCalled();
+            const whatever2 = commonInstance.publicGetterSetterProperty1;
+            expect(commonInstance._spy.publicGetterSetterProperty1._get).toHaveBeenCalledTimes(2);
         });
 
         it('should allow spy setup before its first call', () => {
-            (mockInstance.publicMethod as jasmine.Spy).and.returnValue(999);
-            expect(mockInstance.publicMethod('whatever')).toBe(999);
-            expect(mockInstance.publicMethod('whatever')).toBe(999);
+            (commonInstance.publicMethod1 as jasmine.Spy).and.returnValue(999);
+            expect(commonInstance.publicMethod1('whatever')).toBe(999);
+            expect(commonInstance.publicMethod1('whatever')).toBe(999);
 
-            ((mockInstance as any).privateMethod as jasmine.Spy).and.returnValue(999);
-            expect((mockInstance as any).privateMethod('whatever')).toBe(999);
-            expect((mockInstance as any).privateMethod('whatever')).toBe(999);
+            ((commonInstance as any).privateMethod as jasmine.Spy).and.returnValue(999);
+            expect((commonInstance as any).privateMethod('whatever')).toBe(999);
+            expect((commonInstance as any).privateMethod('whatever')).toBe(999);
         });
 
         it('should allow spy setup after its first call', () => {
-            mockInstance.publicMethod('whatever');
+            commonInstance.publicMethod1('whatever');
 
-            (mockInstance.publicMethod as jasmine.Spy).and.returnValue(111);
-            expect(mockInstance.publicMethod('whatever')).toBe(111);
-            (mockInstance.publicMethod as jasmine.Spy).and.returnValue(999);
-            expect(mockInstance.publicMethod('whatever')).toBe(999);
+            (commonInstance.publicMethod1 as jasmine.Spy).and.returnValue(111);
+            expect(commonInstance.publicMethod1('whatever')).toBe(111);
+            (commonInstance.publicMethod1 as jasmine.Spy).and.returnValue(999);
+            expect(commonInstance.publicMethod1('whatever')).toBe(999);
 
-            (mockInstance as any).privateMethod('whatever');
+            (commonInstance as any).privateMethod('whatever');
 
-            ((mockInstance as any).privateMethod as jasmine.Spy).and.returnValue(111);
-            expect((mockInstance as any).privateMethod('whatever')).toBe(111);
-            ((mockInstance as any).privateMethod as jasmine.Spy).and.returnValue(999);
-            expect((mockInstance as any).privateMethod('whatever')).toBe(999);
+            ((commonInstance as any).privateMethod as jasmine.Spy).and.returnValue(111);
+            expect((commonInstance as any).privateMethod('whatever')).toBe(111);
+            ((commonInstance as any).privateMethod as jasmine.Spy).and.returnValue(999);
+            expect((commonInstance as any).privateMethod('whatever')).toBe(999);
         });
 
         it('should allow spy to be added with non-exist names', () => {
-            (mockInstance as any).nonExistMethod = jasmine.createSpy('newSpy');
-            (mockInstance as any).nonExistMethod('value-1');
-            expect((mockInstance as any).nonExistMethod).toHaveBeenCalledWith('value-1');
+            (commonInstance as any).nonExistMethod = jasmine.createSpy('newSpy');
+            (commonInstance as any).nonExistMethod('value-1');
+            expect((commonInstance as any).nonExistMethod).toHaveBeenCalledWith('value-1');
         });
 
         it('should allow spy to be replaced before its first call', () => {
             const newSpy1 = jasmine.createSpy('newSpy')
-            expect(() => mockInstance.publicMethod = newSpy1).not.toThrowError();
-            mockInstance.publicMethod('value-1');
+            expect(() => commonInstance.publicMethod1 = newSpy1).not.toThrowError();
+            commonInstance.publicMethod1('value-1');
 
             expect(newSpy1).toHaveBeenCalledWith('value-1');
 
             const newSpy2 = jasmine.createSpy('newSpy')
-            expect(() => (mockInstance as any).privateMethod = newSpy2).not.toThrowError();
-            (mockInstance as any).privateMethod('value-1');
+            expect(() => (commonInstance as any).privateMethod = newSpy2).not.toThrowError();
+            (commonInstance as any).privateMethod('value-1');
 
             expect(newSpy2).toHaveBeenCalledWith('value-1');
         });
 
         it('should allow spy to be replaced after its first call', () => {
-            mockInstance.publicMethod('whatever');
+            commonInstance.publicMethod1('whatever');
             const newSpy1 = jasmine.createSpy('newSpy')
-            expect(() => mockInstance.publicMethod = newSpy1).not.toThrowError();
-            mockInstance.publicMethod('value-1');
+            expect(() => commonInstance.publicMethod1 = newSpy1).not.toThrowError();
+            commonInstance.publicMethod1('value-1');
 
             expect(newSpy1).toHaveBeenCalledWith('value-1');
 
-            (mockInstance as any).privateMethod('whatever');
+            (commonInstance as any).privateMethod('whatever');
             const newSpy2 = jasmine.createSpy('newSpy')
-            expect(() => (mockInstance as any).privateMethod = newSpy2).not.toThrowError();
-            (mockInstance as any).privateMethod('value-1');
+            expect(() => (commonInstance as any).privateMethod = newSpy2).not.toThrowError();
+            (commonInstance as any).privateMethod('value-1');
 
             expect(newSpy2).toHaveBeenCalledWith('value-1');
         });
 
         it('should throw when _spy facade is modified', () => {
-            expect(() => mockInstance._spy = 42 as any).toThrow();
-            expect(() => mockInstance._spy.getSetProperty1 = {} as any).toThrow();
+            expect(() => commonInstance._spy = 42 as any).toThrow();
+            expect(() => commonInstance._spy.publicGetterSetterProperty1 = {} as any).toThrow();
         });
     }
 });

--- a/src/lib/index.spec.ts
+++ b/src/lib/index.spec.ts
@@ -391,17 +391,17 @@ describe('Using mocks', () => {
                 expect(commonInstance._spy.publicSetterProperty1._get).not.toHaveBeenCalled();
                 expect(commonInstance._spy.publicGetterSetterProperty1._get).not.toHaveBeenCalled();
 
-                expect(commonInstance._spy['protectedProperty1']._get).not.toHaveBeenCalled();
-                expect(commonInstance._spy['protectedGetterProperty1']._get).not.toHaveBeenCalled();
-                expect(commonInstance._spy['protectedSetterProperty1']._get).not.toHaveBeenCalled();
-                expect(commonInstance._spy['protectedGetterSetterProperty1']._get).not.toHaveBeenCalled();
+                expect(commonInstance._spy.protectedProperty1._get).not.toHaveBeenCalled();
+                expect(commonInstance._spy.protectedGetterProperty1._get).not.toHaveBeenCalled();
+                expect(commonInstance._spy.protectedSetterProperty1._get).not.toHaveBeenCalled();
+                expect(commonInstance._spy.protectedGetterSetterProperty1._get).not.toHaveBeenCalled();
 
-                expect(commonInstance._spy['privateProperty1']._get).not.toHaveBeenCalled();
-                expect(commonInstance._spy['privateGetterProperty1']._get).not.toHaveBeenCalled();
-                expect(commonInstance._spy['privateSetterProperty1']._get).not.toHaveBeenCalled();
-                expect(commonInstance._spy['privateGetterSetterProperty1']._get).not.toHaveBeenCalled();
+                expect(commonInstance._spy.privateProperty1._get).not.toHaveBeenCalled();
+                expect(commonInstance._spy.privateGetterProperty1._get).not.toHaveBeenCalled();
+                expect(commonInstance._spy.privateSetterProperty1._get).not.toHaveBeenCalled();
+                expect(commonInstance._spy.privateGetterSetterProperty1._get).not.toHaveBeenCalled();
 
-                expect(commonInstance._spy['nonExistProperty']._get).not.toHaveBeenCalled();
+                expect(commonInstance._spy.nonExistProperty._get).not.toHaveBeenCalled();
             });
 
             it('should spy setters before they are used', () => {
@@ -410,17 +410,17 @@ describe('Using mocks', () => {
                 expect(commonInstance._spy.publicSetterProperty1._set).not.toHaveBeenCalled();
                 expect(commonInstance._spy.publicGetterSetterProperty1._set).not.toHaveBeenCalled();
 
-                expect(commonInstance._spy['protectedProperty1']._set).not.toHaveBeenCalled();
-                expect(commonInstance._spy['protectedGetterProperty1']._set).not.toHaveBeenCalled();
-                expect(commonInstance._spy['protectedSetterProperty1']._set).not.toHaveBeenCalled();
-                expect(commonInstance._spy['protectedGetterSetterProperty1']._set).not.toHaveBeenCalled();
+                expect(commonInstance._spy.protectedProperty1._set).not.toHaveBeenCalled();
+                expect(commonInstance._spy.protectedGetterProperty1._set).not.toHaveBeenCalled();
+                expect(commonInstance._spy.protectedSetterProperty1._set).not.toHaveBeenCalled();
+                expect(commonInstance._spy.protectedGetterSetterProperty1._set).not.toHaveBeenCalled();
 
-                expect(commonInstance._spy['privateProperty1']._set).not.toHaveBeenCalled();
-                expect(commonInstance._spy['privateGetterProperty1']._set).not.toHaveBeenCalled();
-                expect(commonInstance._spy['privateSetterProperty1']._set).not.toHaveBeenCalled();
-                expect(commonInstance._spy['privateGetterSetterProperty1']._set).not.toHaveBeenCalled();
+                expect(commonInstance._spy.privateProperty1._set).not.toHaveBeenCalled();
+                expect(commonInstance._spy.privateGetterProperty1._set).not.toHaveBeenCalled();
+                expect(commonInstance._spy.privateSetterProperty1._set).not.toHaveBeenCalled();
+                expect(commonInstance._spy.privateGetterSetterProperty1._set).not.toHaveBeenCalled();
 
-                expect(commonInstance._spy['nonExistProperty']._set).not.toHaveBeenCalled();
+                expect(commonInstance._spy.nonExistProperty._set).not.toHaveBeenCalled();
             });
 
             it('should record calls on getters', () => {
@@ -445,40 +445,40 @@ describe('Using mocks', () => {
                 temp1 = commonInstance['protectedGetterProperty1'];
                 temp1 = commonInstance['protectedSetterProperty1'];
                 temp1 = commonInstance['protectedGetterSetterProperty1'];
-                expect(commonInstance._spy['protectedProperty1']._get).toHaveBeenCalled();
-                expect(commonInstance._spy['protectedGetterProperty1']._get).toHaveBeenCalled();
-                expect(commonInstance._spy['protectedSetterProperty1']._get).toHaveBeenCalled();
-                expect(commonInstance._spy['protectedGetterSetterProperty1']._get).toHaveBeenCalled();
+                expect(commonInstance._spy.protectedProperty1._get).toHaveBeenCalled();
+                expect(commonInstance._spy.protectedGetterProperty1._get).toHaveBeenCalled();
+                expect(commonInstance._spy.protectedSetterProperty1._get).toHaveBeenCalled();
+                expect(commonInstance._spy.protectedGetterSetterProperty1._get).toHaveBeenCalled();
                 temp1 = commonInstance['protectedProperty1'];
                 temp1 = commonInstance['protectedGetterProperty1'];
                 temp1 = commonInstance['protectedSetterProperty1'];
                 temp1 = commonInstance['protectedGetterSetterProperty1'];
-                expect(commonInstance._spy['protectedProperty1']._get).toHaveBeenCalledTimes(2);
-                expect(commonInstance._spy['protectedGetterProperty1']._get).toHaveBeenCalledTimes(2);
-                expect(commonInstance._spy['protectedSetterProperty1']._get).toHaveBeenCalledTimes(2);
-                expect(commonInstance._spy['protectedGetterSetterProperty1']._get).toHaveBeenCalledTimes(2);
+                expect(commonInstance._spy.protectedProperty1._get).toHaveBeenCalledTimes(2);
+                expect(commonInstance._spy.protectedGetterProperty1._get).toHaveBeenCalledTimes(2);
+                expect(commonInstance._spy.protectedSetterProperty1._get).toHaveBeenCalledTimes(2);
+                expect(commonInstance._spy.protectedGetterSetterProperty1._get).toHaveBeenCalledTimes(2);
 
                 temp1 = commonInstance['privateProperty1'];
                 temp1 = commonInstance['privateGetterProperty1'];
                 temp1 = commonInstance['privateSetterProperty1'];
                 temp1 = commonInstance['privateGetterSetterProperty1'];
-                expect(commonInstance._spy['privateProperty1']._get).toHaveBeenCalled();
-                expect(commonInstance._spy['privateGetterProperty1']._get).toHaveBeenCalled();
-                expect(commonInstance._spy['privateSetterProperty1']._get).toHaveBeenCalled();
-                expect(commonInstance._spy['privateGetterSetterProperty1']._get).toHaveBeenCalled();
+                expect(commonInstance._spy.privateProperty1._get).toHaveBeenCalled();
+                expect(commonInstance._spy.privateGetterProperty1._get).toHaveBeenCalled();
+                expect(commonInstance._spy.privateSetterProperty1._get).toHaveBeenCalled();
+                expect(commonInstance._spy.privateGetterSetterProperty1._get).toHaveBeenCalled();
                 temp1 = commonInstance['privateProperty1'];
                 temp1 = commonInstance['privateGetterProperty1'];
                 temp1 = commonInstance['privateSetterProperty1'];
                 temp1 = commonInstance['privateGetterSetterProperty1'];
-                expect(commonInstance._spy['privateProperty1']._get).toHaveBeenCalledTimes(2);
-                expect(commonInstance._spy['privateGetterProperty1']._get).toHaveBeenCalledTimes(2);
-                expect(commonInstance._spy['privateSetterProperty1']._get).toHaveBeenCalledTimes(2);
-                expect(commonInstance._spy['privateGetterSetterProperty1']._get).toHaveBeenCalledTimes(2);
+                expect(commonInstance._spy.privateProperty1._get).toHaveBeenCalledTimes(2);
+                expect(commonInstance._spy.privateGetterProperty1._get).toHaveBeenCalledTimes(2);
+                expect(commonInstance._spy.privateSetterProperty1._get).toHaveBeenCalledTimes(2);
+                expect(commonInstance._spy.privateGetterSetterProperty1._get).toHaveBeenCalledTimes(2);
 
                 temp1 = commonInstance['nonExistProperty'];
-                expect(commonInstance._spy['nonExistProperty']._get).toHaveBeenCalled();
+                expect(commonInstance._spy.nonExistProperty._get).toHaveBeenCalled();
                 temp1 = commonInstance['nonExistProperty'];
-                expect(commonInstance._spy['nonExistProperty']._get).toHaveBeenCalledTimes(2);
+                expect(commonInstance._spy.nonExistProperty._get).toHaveBeenCalledTimes(2);
             });
 
             it('should record calls on setters', () => {
@@ -503,40 +503,40 @@ describe('Using mocks', () => {
                 commonInstance['protectedGetterProperty1'] = 'new-value';
                 commonInstance['protectedSetterProperty1'] = 'new-value';
                 commonInstance['protectedGetterSetterProperty1'] = 'new-value';
-                expect(commonInstance._spy['protectedProperty1']._set).toHaveBeenCalledWith('new-value');
-                expect(commonInstance._spy['protectedGetterProperty1']._set).toHaveBeenCalledWith('new-value');
-                expect(commonInstance._spy['protectedSetterProperty1']._set).toHaveBeenCalledWith('new-value');
-                expect(commonInstance._spy['protectedGetterSetterProperty1']._set).toHaveBeenCalledWith('new-value');
+                expect(commonInstance._spy.protectedProperty1._set).toHaveBeenCalledWith('new-value');
+                expect(commonInstance._spy.protectedGetterProperty1._set).toHaveBeenCalledWith('new-value');
+                expect(commonInstance._spy.protectedSetterProperty1._set).toHaveBeenCalledWith('new-value');
+                expect(commonInstance._spy.protectedGetterSetterProperty1._set).toHaveBeenCalledWith('new-value');
                 commonInstance['protectedProperty1'] = 'new-value';
                 commonInstance['protectedGetterProperty1'] = 'new-value';
                 commonInstance['protectedSetterProperty1'] = 'new-value';
                 commonInstance['protectedGetterSetterProperty1'] = 'new-value';
-                expect(commonInstance._spy['protectedProperty1']._set).toHaveBeenCalledTimes(2);
-                expect(commonInstance._spy['protectedGetterProperty1']._set).toHaveBeenCalledTimes(2);
-                expect(commonInstance._spy['protectedSetterProperty1']._set).toHaveBeenCalledTimes(2);
-                expect(commonInstance._spy['protectedGetterSetterProperty1']._set).toHaveBeenCalledTimes(2);
+                expect(commonInstance._spy.protectedProperty1._set).toHaveBeenCalledTimes(2);
+                expect(commonInstance._spy.protectedGetterProperty1._set).toHaveBeenCalledTimes(2);
+                expect(commonInstance._spy.protectedSetterProperty1._set).toHaveBeenCalledTimes(2);
+                expect(commonInstance._spy.protectedGetterSetterProperty1._set).toHaveBeenCalledTimes(2);
 
                 commonInstance['privateProperty1'] = 'new-value';
                 commonInstance['privateGetterProperty1'] = 'new-value';
                 commonInstance['privateSetterProperty1'] = 'new-value';
                 commonInstance['privateGetterSetterProperty1'] = 'new-value';
-                expect(commonInstance._spy['privateProperty1']._set).toHaveBeenCalledWith('new-value');
-                expect(commonInstance._spy['privateGetterProperty1']._set).toHaveBeenCalledWith('new-value');
-                expect(commonInstance._spy['privateSetterProperty1']._set).toHaveBeenCalledWith('new-value');
-                expect(commonInstance._spy['privateGetterSetterProperty1']._set).toHaveBeenCalledWith('new-value');
+                expect(commonInstance._spy.privateProperty1._set).toHaveBeenCalledWith('new-value');
+                expect(commonInstance._spy.privateGetterProperty1._set).toHaveBeenCalledWith('new-value');
+                expect(commonInstance._spy.privateSetterProperty1._set).toHaveBeenCalledWith('new-value');
+                expect(commonInstance._spy.privateGetterSetterProperty1._set).toHaveBeenCalledWith('new-value');
                 commonInstance['privateProperty1'] = 'new-value';
                 commonInstance['privateGetterProperty1'] = 'new-value';
                 commonInstance['privateSetterProperty1'] = 'new-value';
                 commonInstance['privateGetterSetterProperty1'] = 'new-value';
-                expect(commonInstance._spy['privateProperty1']._set).toHaveBeenCalledTimes(2);
-                expect(commonInstance._spy['privateGetterProperty1']._set).toHaveBeenCalledTimes(2);
-                expect(commonInstance._spy['privateSetterProperty1']._set).toHaveBeenCalledTimes(2);
-                expect(commonInstance._spy['privateGetterSetterProperty1']._set).toHaveBeenCalledTimes(2);
+                expect(commonInstance._spy.privateProperty1._set).toHaveBeenCalledTimes(2);
+                expect(commonInstance._spy.privateGetterProperty1._set).toHaveBeenCalledTimes(2);
+                expect(commonInstance._spy.privateSetterProperty1._set).toHaveBeenCalledTimes(2);
+                expect(commonInstance._spy.privateGetterSetterProperty1._set).toHaveBeenCalledTimes(2);
 
                 commonInstance['nonExistProperty'] = 'new-value';
-                expect(commonInstance._spy['nonExistProperty']._set).toHaveBeenCalledWith('new-value');
+                expect(commonInstance._spy.nonExistProperty._set).toHaveBeenCalledWith('new-value');
                 commonInstance['nonExistProperty'] = 'new-value';
-                expect(commonInstance._spy['nonExistProperty']._set).toHaveBeenCalledTimes(2);
+                expect(commonInstance._spy.nonExistProperty._set).toHaveBeenCalledTimes(2);
             });
 
             it('should modify results from getters before they are used', () => {
@@ -549,25 +549,25 @@ describe('Using mocks', () => {
                 expect(commonInstance.publicSetterProperty1).toBe('new-value-1');
                 expect(commonInstance.publicGetterSetterProperty1).toBe('new-value-1');
 
-                commonInstance._spy['protectedProperty1']._get.and.returnValue('new-value-1');
-                commonInstance._spy['protectedGetterProperty1']._get.and.returnValue('new-value-1');
-                commonInstance._spy['protectedSetterProperty1']._get.and.returnValue('new-value-1');
-                commonInstance._spy['protectedGetterSetterProperty1']._get.and.returnValue('new-value-1');
+                commonInstance._spy.protectedProperty1._get.and.returnValue('new-value-1');
+                commonInstance._spy.protectedGetterProperty1._get.and.returnValue('new-value-1');
+                commonInstance._spy.protectedSetterProperty1._get.and.returnValue('new-value-1');
+                commonInstance._spy.protectedGetterSetterProperty1._get.and.returnValue('new-value-1');
                 expect(commonInstance['protectedProperty1']).toBe('new-value-1');
                 expect(commonInstance['protectedGetterProperty1']).toBe('new-value-1');
                 expect(commonInstance['protectedSetterProperty1']).toBe('new-value-1');
                 expect(commonInstance['protectedGetterSetterProperty1']).toBe('new-value-1');
 
-                commonInstance._spy['privateProperty1']._get.and.returnValue('new-value-1');
-                commonInstance._spy['privateGetterProperty1']._get.and.returnValue('new-value-1');
-                commonInstance._spy['privateSetterProperty1']._get.and.returnValue('new-value-1');
-                commonInstance._spy['privateGetterSetterProperty1']._get.and.returnValue('new-value-1');
+                commonInstance._spy.privateProperty1._get.and.returnValue('new-value-1');
+                commonInstance._spy.privateGetterProperty1._get.and.returnValue('new-value-1');
+                commonInstance._spy.privateSetterProperty1._get.and.returnValue('new-value-1');
+                commonInstance._spy.privateGetterSetterProperty1._get.and.returnValue('new-value-1');
                 expect(commonInstance['privateProperty1']).toBe('new-value-1');
                 expect(commonInstance['privateGetterProperty1']).toBe('new-value-1');
                 expect(commonInstance['privateSetterProperty1']).toBe('new-value-1');
                 expect(commonInstance['privateGetterSetterProperty1']).toBe('new-value-1');
 
-                commonInstance._spy['nonExistProperty']._get.and.returnValue('new-value-1');
+                commonInstance._spy.nonExistProperty._get.and.returnValue('new-value-1');
                 expect(commonInstance['nonExistProperty']).toBe('new-value-1');
             });
 
@@ -589,10 +589,10 @@ describe('Using mocks', () => {
                 temp = commonInstance['protectedGetterProperty1'];
                 temp = commonInstance['protectedSetterProperty1'];
                 temp = commonInstance['protectedGetterSetterProperty1'];
-                commonInstance._spy['protectedProperty1']._get.and.returnValue('new-value-1');
-                commonInstance._spy['protectedGetterProperty1']._get.and.returnValue('new-value-1');
-                commonInstance._spy['protectedSetterProperty1']._get.and.returnValue('new-value-1');
-                commonInstance._spy['protectedGetterSetterProperty1']._get.and.returnValue('new-value-1');
+                commonInstance._spy.protectedProperty1._get.and.returnValue('new-value-1');
+                commonInstance._spy.protectedGetterProperty1._get.and.returnValue('new-value-1');
+                commonInstance._spy.protectedSetterProperty1._get.and.returnValue('new-value-1');
+                commonInstance._spy.protectedGetterSetterProperty1._get.and.returnValue('new-value-1');
                 expect(commonInstance['protectedProperty1']).toBe('new-value-1');
                 expect(commonInstance['protectedGetterProperty1']).toBe('new-value-1');
                 expect(commonInstance['protectedSetterProperty1']).toBe('new-value-1');
@@ -602,17 +602,17 @@ describe('Using mocks', () => {
                 temp = commonInstance['privateGetterProperty1'];
                 temp = commonInstance['privateSetterProperty1'];
                 temp = commonInstance['privateGetterSetterProperty1']
-                commonInstance._spy['privateProperty1']._get.and.returnValue('new-value-1');
-                commonInstance._spy['privateGetterProperty1']._get.and.returnValue('new-value-1');
-                commonInstance._spy['privateSetterProperty1']._get.and.returnValue('new-value-1');
-                commonInstance._spy['privateGetterSetterProperty1']._get.and.returnValue('new-value-1');
+                commonInstance._spy.privateProperty1._get.and.returnValue('new-value-1');
+                commonInstance._spy.privateGetterProperty1._get.and.returnValue('new-value-1');
+                commonInstance._spy.privateSetterProperty1._get.and.returnValue('new-value-1');
+                commonInstance._spy.privateGetterSetterProperty1._get.and.returnValue('new-value-1');
                 expect(commonInstance['privateProperty1']).toBe('new-value-1');
                 expect(commonInstance['privateGetterProperty1']).toBe('new-value-1');
                 expect(commonInstance['privateSetterProperty1']).toBe('new-value-1');
                 expect(commonInstance['privateGetterSetterProperty1']).toBe('new-value-1');
 
                 temp = commonInstance['nonExistProperty'];
-                commonInstance._spy['nonExistProperty']._get.and.returnValue('new-value-1');
+                commonInstance._spy.nonExistProperty._get.and.returnValue('new-value-1');
                 expect(commonInstance['nonExistProperty']).toBe('new-value-1');
             });
 
@@ -630,36 +630,119 @@ describe('Using mocks', () => {
                 expect(commonInstance.publicSetterProperty1).toBe('new-value-2');
                 expect(commonInstance.publicGetterSetterProperty1).toBe('new-value-2');
 
-                commonInstance._spy['protectedProperty1']._get.and.returnValue('new-value-1');
-                commonInstance._spy['protectedGetterProperty1']._get.and.returnValue('new-value-1');
-                commonInstance._spy['protectedSetterProperty1']._get.and.returnValue('new-value-1');
-                commonInstance._spy['protectedGetterSetterProperty1']._get.and.returnValue('new-value-1');
-                commonInstance._spy['protectedProperty1']._get.and.returnValue('new-value-2');
-                commonInstance._spy['protectedGetterProperty1']._get.and.returnValue('new-value-2');
-                commonInstance._spy['protectedSetterProperty1']._get.and.returnValue('new-value-2');
-                commonInstance._spy['protectedGetterSetterProperty1']._get.and.returnValue('new-value-2');
+                commonInstance._spy.protectedProperty1._get.and.returnValue('new-value-1');
+                commonInstance._spy.protectedGetterProperty1._get.and.returnValue('new-value-1');
+                commonInstance._spy.protectedSetterProperty1._get.and.returnValue('new-value-1');
+                commonInstance._spy.protectedGetterSetterProperty1._get.and.returnValue('new-value-1');
+                commonInstance._spy.protectedProperty1._get.and.returnValue('new-value-2');
+                commonInstance._spy.protectedGetterProperty1._get.and.returnValue('new-value-2');
+                commonInstance._spy.protectedSetterProperty1._get.and.returnValue('new-value-2');
+                commonInstance._spy.protectedGetterSetterProperty1._get.and.returnValue('new-value-2');
                 expect(commonInstance['protectedProperty1']).toBe('new-value-2');
                 expect(commonInstance['protectedGetterProperty1']).toBe('new-value-2');
                 expect(commonInstance['protectedSetterProperty1']).toBe('new-value-2');
                 expect(commonInstance['protectedGetterSetterProperty1']).toBe('new-value-2');
 
-                commonInstance._spy['privateProperty1']._get.and.returnValue('new-value-1');
-                commonInstance._spy['privateGetterProperty1']._get.and.returnValue('new-value-1');
-                commonInstance._spy['privateSetterProperty1']._get.and.returnValue('new-value-1');
-                commonInstance._spy['privateGetterSetterProperty1']._get.and.returnValue('new-value-1');
-                commonInstance._spy['privateProperty1']._get.and.returnValue('new-value-2');
-                commonInstance._spy['privateGetterProperty1']._get.and.returnValue('new-value-2');
-                commonInstance._spy['privateSetterProperty1']._get.and.returnValue('new-value-2');
-                commonInstance._spy['privateGetterSetterProperty1']._get.and.returnValue('new-value-2');
+                commonInstance._spy.privateProperty1._get.and.returnValue('new-value-1');
+                commonInstance._spy.privateGetterProperty1._get.and.returnValue('new-value-1');
+                commonInstance._spy.privateSetterProperty1._get.and.returnValue('new-value-1');
+                commonInstance._spy.privateGetterSetterProperty1._get.and.returnValue('new-value-1');
+                commonInstance._spy.privateProperty1._get.and.returnValue('new-value-2');
+                commonInstance._spy.privateGetterProperty1._get.and.returnValue('new-value-2');
+                commonInstance._spy.privateSetterProperty1._get.and.returnValue('new-value-2');
+                commonInstance._spy.privateGetterSetterProperty1._get.and.returnValue('new-value-2');
                 expect(commonInstance['privateProperty1']).toBe('new-value-2');
                 expect(commonInstance['privateGetterProperty1']).toBe('new-value-2');
                 expect(commonInstance['privateSetterProperty1']).toBe('new-value-2');
                 expect(commonInstance['privateGetterSetterProperty1']).toBe('new-value-2');
 
-                commonInstance._spy['nonExistProperty']._get.and.returnValue('new-value-1');
-                commonInstance._spy['nonExistProperty']._get.and.returnValue('new-value-2');
+                commonInstance._spy.nonExistProperty._get.and.returnValue('new-value-1');
+                commonInstance._spy.nonExistProperty._get.and.returnValue('new-value-2');
                 expect(commonInstance['nonExistProperty']).toBe('new-value-2');
             });
+
+            it('should respect getters despite direct modification on properties', () => {
+                commonInstance._spy.publicProperty1._get.and.returnValue('new-value-1');
+                commonInstance._spy.publicGetterProperty1._get.and.returnValue('new-value-1');
+                commonInstance._spy.publicSetterProperty1._get.and.returnValue('new-value-1');
+                commonInstance._spy.publicGetterSetterProperty1._get.and.returnValue('new-value-1');
+                commonInstance.publicProperty1 = 'new-value-2';
+                (commonInstance as any).publicGetterProperty1 = 'new-value-2';
+                commonInstance.publicSetterProperty1 = 'new-value-2';
+                commonInstance.publicGetterSetterProperty1 = 'new-value-2';
+                expect(commonInstance.publicProperty1).toBe('new-value-1');
+                expect((commonInstance as any).publicGetterProperty1).toBe('new-value-1');
+                expect(commonInstance.publicSetterProperty1).toBe('new-value-1');
+                expect(commonInstance.publicGetterSetterProperty1).toBe('new-value-1');
+
+                commonInstance._spy.protectedProperty1._get.and.returnValue('new-value-1');
+                commonInstance._spy.protectedGetterProperty1._get.and.returnValue('new-value-1');
+                commonInstance._spy.protectedSetterProperty1._get.and.returnValue('new-value-1');
+                commonInstance._spy.protectedGetterSetterProperty1._get.and.returnValue('new-value-1');
+                commonInstance['protectedProperty1'] = 'new-value-2';
+                (commonInstance as any).protectedGetterProperty1 = 'new-value-2';
+                commonInstance['protectedSetterProperty1'] = 'new-value-2';
+                commonInstance['protectedGetterSetterProperty1'] = 'new-value-2';
+                expect(commonInstance['protectedProperty1']).toBe('new-value-1');
+                expect((commonInstance as any).protectedGetterProperty1).toBe('new-value-1');
+                expect(commonInstance['protectedSetterProperty1']).toBe('new-value-1');
+                expect(commonInstance['protectedGetterSetterProperty1']).toBe('new-value-1');
+
+                commonInstance._spy.privateProperty1._get.and.returnValue('new-value-1');
+                commonInstance._spy.privateGetterProperty1._get.and.returnValue('new-value-1');
+                commonInstance._spy.privateSetterProperty1._get.and.returnValue('new-value-1');
+                commonInstance._spy.privateGetterSetterProperty1._get.and.returnValue('new-value-1');
+                commonInstance['privateProperty1'] = 'new-value-2';
+                (commonInstance as any).privateGetterProperty1 = 'new-value-2';
+                commonInstance['privateSetterProperty1'] = 'new-value-2';
+                commonInstance['privateGetterSetterProperty1'] = 'new-value-2';
+                expect(commonInstance['privateProperty1']).toBe('new-value-1');
+                expect((commonInstance as any).privateGetterProperty1).toBe('new-value-1');
+                expect(commonInstance['privateSetterProperty1']).toBe('new-value-1');
+                expect(commonInstance['privateGetterSetterProperty1']).toBe('new-value-1');
+            });
+
+            it('should respect setters despite direct modification on properties', () => {
+                commonInstance._spy.publicProperty1._set.and.callFake(() => { /* noop */});
+                commonInstance._spy.publicGetterProperty1._set.and.callFake(() => { /* noop */});
+                commonInstance._spy.publicSetterProperty1._set.and.callFake(() => { /* noop */});
+                commonInstance._spy.publicGetterSetterProperty1._set.and.callFake(() => { /* noop */});
+                commonInstance.publicProperty1 = 'new-value-1';
+                (commonInstance as any).publicGetterProperty1 = 'new-value-1';
+                commonInstance.publicSetterProperty1 = 'new-value-1';
+                commonInstance.publicGetterSetterProperty1 = 'new-value-1';
+                expect(commonInstance.publicProperty1).toBeUndefined();
+                expect((commonInstance as any).publicGetterProperty1).toBeUndefined();
+                expect(commonInstance.publicSetterProperty1).toBeUndefined();
+                expect(commonInstance.publicGetterSetterProperty1).toBeUndefined();
+
+                commonInstance._spy.protectedProperty1._set.and.callFake(() => { /* noop */});
+                commonInstance._spy.protectedGetterProperty1._set.and.callFake(() => { /* noop */});
+                commonInstance._spy.protectedSetterProperty1._set.and.callFake(() => { /* noop */});
+                commonInstance._spy.protectedGetterSetterProperty1._set.and.callFake(() => { /* noop */});
+                commonInstance['protectedProperty1'] = 'new-value-1';
+                (commonInstance as any).protectedGetterProperty1 = 'new-value-1';
+                commonInstance['protectedSetterProperty1'] = 'new-value-1';
+                commonInstance['protectedGetterSetterProperty1'] = 'new-value-1';
+                expect(commonInstance['protectedProperty1']).toBeUndefined();
+                expect((commonInstance as any).protectedGetterProperty1).toBeUndefined();
+                expect(commonInstance['protectedSetterProperty1']).toBeUndefined();
+                expect(commonInstance['protectedGetterSetterProperty1']).toBeUndefined();
+
+                commonInstance._spy.privateProperty1._set.and.callFake(() => { /* noop */});
+                commonInstance._spy.privateGetterProperty1._set.and.callFake(() => { /* noop */});
+                commonInstance._spy.privateSetterProperty1._set.and.callFake(() => { /* noop */});
+                commonInstance._spy.privateGetterSetterProperty1._set.and.callFake(() => { /* noop */});
+                commonInstance['privateProperty1'] = 'new-value-1';
+                (commonInstance as any).privateGetterProperty1 = 'new-value-1';
+                commonInstance['privateSetterProperty1'] = 'new-value-1';
+                commonInstance['privateGetterSetterProperty1'] = 'new-value-1';
+                expect(commonInstance['privateProperty1']).toBeUndefined();
+                expect((commonInstance as any).privateGetterProperty1).toBeUndefined();
+                expect(commonInstance['privateSetterProperty1']).toBeUndefined();
+                expect(commonInstance['privateGetterSetterProperty1']).toBeUndefined();
+            });
+
 
             it('should not allow spiedMembers to be replaced via spyFacade', () => {
                 expect(() => commonInstance._spy.publicProperty1 = {}).toThrow();
@@ -667,17 +750,17 @@ describe('Using mocks', () => {
                 expect(() => commonInstance._spy.publicSetterProperty1 = {}).toThrow();
                 expect(() => commonInstance._spy.publicGetterSetterProperty1 = {}).toThrow();
 
-                expect(() => (commonInstance._spy['protectedProperty1'] = {})).toThrow();
-                expect(() => (commonInstance._spy['protectedGetterProperty1'] = {})).toThrow();
-                expect(() => (commonInstance._spy['protectedSetterProperty1'] = {})).toThrow();
-                expect(() => (commonInstance._spy['protectedGetterSetterProperty1'] = {})).toThrow();
+                expect(() => (commonInstance._spy.protectedProperty1 = {})).toThrow();
+                expect(() => (commonInstance._spy.protectedGetterProperty1 = {})).toThrow();
+                expect(() => (commonInstance._spy.protectedSetterProperty1 = {})).toThrow();
+                expect(() => (commonInstance._spy.protectedGetterSetterProperty1 = {})).toThrow();
 
-                expect(() => (commonInstance._spy['privateProperty1'] = {})).toThrow();
-                expect(() => (commonInstance._spy['privateGetterProperty1'] = {})).toThrow();
-                expect(() => (commonInstance._spy['privateSetterProperty1'] = {})).toThrow();
-                expect(() => (commonInstance._spy['privateGetterSetterProperty1'] = {})).toThrow();
+                expect(() => (commonInstance._spy.privateProperty1 = {})).toThrow();
+                expect(() => (commonInstance._spy.privateGetterProperty1 = {})).toThrow();
+                expect(() => (commonInstance._spy.privateSetterProperty1 = {})).toThrow();
+                expect(() => (commonInstance._spy.privateGetterSetterProperty1 = {})).toThrow();
 
-                expect(() => (commonInstance._spy['nonExistProperty'] = {})).toThrow();
+                expect(() => (commonInstance._spy.nonExistProperty = {})).toThrow();
             });
 
             it('should not allow reading _func on properties', () => {
@@ -686,17 +769,17 @@ describe('Using mocks', () => {
                 expect(() => commonInstance._spy.publicSetterProperty1._func).toThrow();
                 expect(() => commonInstance._spy.publicGetterSetterProperty1._func).toThrow();
 
-                expect(() => (commonInstance._spy['protectedProperty1']._func)).toThrow();
-                expect(() => (commonInstance._spy['protectedGetterProperty1']._func)).toThrow();
-                expect(() => (commonInstance._spy['protectedSetterProperty1']._func)).toThrow();
-                expect(() => (commonInstance._spy['protectedGetterSetterProperty1']._func)).toThrow();
+                expect(() => (commonInstance._spy.protectedProperty1._func)).toThrow();
+                expect(() => (commonInstance._spy.protectedGetterProperty1._func)).toThrow();
+                expect(() => (commonInstance._spy.protectedSetterProperty1._func)).toThrow();
+                expect(() => (commonInstance._spy.protectedGetterSetterProperty1._func)).toThrow();
 
-                expect(() => (commonInstance._spy['privateProperty1']._func)).toThrow();
-                expect(() => (commonInstance._spy['privateGetterProperty1']._func)).toThrow();
-                expect(() => (commonInstance._spy['privateSetterProperty1']._func)).toThrow();
-                expect(() => (commonInstance._spy['privateGetterSetterProperty1']._func)).toThrow();
+                expect(() => (commonInstance._spy.privateProperty1._func)).toThrow();
+                expect(() => (commonInstance._spy.privateGetterProperty1._func)).toThrow();
+                expect(() => (commonInstance._spy.privateSetterProperty1._func)).toThrow();
+                expect(() => (commonInstance._spy.privateGetterSetterProperty1._func)).toThrow();
 
-                expect(() => (commonInstance._spy['nonExistProperty']._func)).toThrow();
+                expect(() => (commonInstance._spy.nonExistProperty._func)).toThrow();
             });
 
             it('should not allow writing _func on properties', () => {
@@ -705,17 +788,17 @@ describe('Using mocks', () => {
                 expect(() => commonInstance._spy.publicSetterProperty1._func = jasmine.createSpy('whatever')).toThrow();
                 expect(() => commonInstance._spy.publicGetterSetterProperty1._func = jasmine.createSpy('whatever')).toThrow();
 
-                expect(() => (commonInstance._spy['protectedProperty1']._func = jasmine.createSpy('whatever'))).toThrow();
-                expect(() => (commonInstance._spy['protectedGetterProperty1']._func = jasmine.createSpy('whatever'))).toThrow();
-                expect(() => (commonInstance._spy['protectedSetterProperty1']._func = jasmine.createSpy('whatever'))).toThrow();
-                expect(() => (commonInstance._spy['protectedGetterSetterProperty1']._func = jasmine.createSpy('whatever'))).toThrow();
+                expect(() => (commonInstance._spy.protectedProperty1._func = jasmine.createSpy('whatever'))).toThrow();
+                expect(() => (commonInstance._spy.protectedGetterProperty1._func = jasmine.createSpy('whatever'))).toThrow();
+                expect(() => (commonInstance._spy.protectedSetterProperty1._func = jasmine.createSpy('whatever'))).toThrow();
+                expect(() => (commonInstance._spy.protectedGetterSetterProperty1._func = jasmine.createSpy('whatever'))).toThrow();
 
-                expect(() => (commonInstance._spy['privateProperty1']._func = jasmine.createSpy('whatever'))).toThrow();
-                expect(() => (commonInstance._spy['privateGetterProperty1']._func = jasmine.createSpy('whatever'))).toThrow();
-                expect(() => (commonInstance._spy['privateSetterProperty1']._func = jasmine.createSpy('whatever'))).toThrow();
-                expect(() => (commonInstance._spy['privateGetterSetterProperty1']._func = jasmine.createSpy('whatever'))).toThrow();
+                expect(() => (commonInstance._spy.privateProperty1._func = jasmine.createSpy('whatever'))).toThrow();
+                expect(() => (commonInstance._spy.privateGetterProperty1._func = jasmine.createSpy('whatever'))).toThrow();
+                expect(() => (commonInstance._spy.privateSetterProperty1._func = jasmine.createSpy('whatever'))).toThrow();
+                expect(() => (commonInstance._spy.privateGetterSetterProperty1._func = jasmine.createSpy('whatever'))).toThrow();
 
-                expect(() => (commonInstance._spy['nonExistProperty']._func = jasmine.createSpy('whatever'))).toThrow();
+                expect(() => (commonInstance._spy.nonExistProperty._func = jasmine.createSpy('whatever'))).toThrow();
             });
         });
 
@@ -739,17 +822,17 @@ describe('Using mocks', () => {
             it('should return spy from spyFacade for all methods', () => {
                 expect(commonInstance._spy.publicMethod1._func).not.toHaveBeenCalled();
                 expect(commonInstance._spy.publicMethod1._func).not.toHaveBeenCalled();
-                expect((commonInstance._spy as any).protectedMethod1._func).not.toHaveBeenCalled();
-                expect((commonInstance._spy as any).protectedMethod1._func).not.toHaveBeenCalled();
-                expect((commonInstance._spy as any).privateMethod1._func).not.toHaveBeenCalled();
-                expect((commonInstance._spy as any).privateMethod1._func).not.toHaveBeenCalled();
+                expect(commonInstance._spy.protectedMethod1._func).not.toHaveBeenCalled();
+                expect(commonInstance._spy.protectedMethod1._func).not.toHaveBeenCalled();
+                expect(commonInstance._spy.privateMethod1._func).not.toHaveBeenCalled();
+                expect(commonInstance._spy.privateMethod1._func).not.toHaveBeenCalled();
 
                 expect(commonInstance._spy.publicMethod1._func).not.toHaveBeenCalled();
                 expect(commonInstance._spy.publicMethod1._func).not.toHaveBeenCalled();
-                expect(commonInstance._spy['protectedMethod1']._func).not.toHaveBeenCalled();
-                expect(commonInstance._spy['protectedMethod1']._func).not.toHaveBeenCalled();
-                expect(commonInstance._spy['privateMethod1']._func).not.toHaveBeenCalled();
-                expect(commonInstance._spy['privateMethod1']._func).not.toHaveBeenCalled();
+                expect(commonInstance._spy.protectedMethod1._func).not.toHaveBeenCalled();
+                expect(commonInstance._spy.protectedMethod1._func).not.toHaveBeenCalled();
+                expect(commonInstance._spy.privateMethod1._func).not.toHaveBeenCalled();
+                expect(commonInstance._spy.privateMethod1._func).not.toHaveBeenCalled();
             });
 
             it('should register calls on each spy', () => {
@@ -779,17 +862,17 @@ describe('Using mocks', () => {
                 expect(commonInstance._spy.publicMethod1._func).toHaveBeenCalledWith('value-2');
                 expect(commonInstance._spy.publicMethod1._func).toHaveBeenCalledTimes(2);
 
-                (commonInstance._spy as any).protectedMethod1._func('value-1');
-                expect((commonInstance._spy as any).protectedMethod1._func).toHaveBeenCalledWith('value-1');
-                (commonInstance._spy as any).protectedMethod1._func('value-2');
-                expect((commonInstance._spy as any).protectedMethod1._func).toHaveBeenCalledWith('value-2');
-                expect((commonInstance._spy as any).protectedMethod1._func).toHaveBeenCalledTimes(2);
+                commonInstance._spy.protectedMethod1._func('value-1');
+                expect(commonInstance._spy.protectedMethod1._func).toHaveBeenCalledWith('value-1');
+                commonInstance._spy.protectedMethod1._func('value-2');
+                expect(commonInstance._spy.protectedMethod1._func).toHaveBeenCalledWith('value-2');
+                expect(commonInstance._spy.protectedMethod1._func).toHaveBeenCalledTimes(2);
 
-                (commonInstance._spy as any).privateMethod1._func('value-1');
-                expect((commonInstance._spy as any).privateMethod1._func).toHaveBeenCalledWith('value-1');
-                (commonInstance._spy as any).privateMethod1._func('value-2');
-                expect((commonInstance._spy as any).privateMethod1._func).toHaveBeenCalledWith('value-2');
-                expect((commonInstance._spy as any).privateMethod1._func).toHaveBeenCalledTimes(2);
+                commonInstance._spy.privateMethod1._func('value-1');
+                expect(commonInstance._spy.privateMethod1._func).toHaveBeenCalledWith('value-1');
+                commonInstance._spy.privateMethod1._func('value-2');
+                expect(commonInstance._spy.privateMethod1._func).toHaveBeenCalledWith('value-2');
+                expect(commonInstance._spy.privateMethod1._func).toHaveBeenCalledTimes(2);
             });
 
             it('should register calls on each spy when calls are made after the spys are inspected', () => {
@@ -834,11 +917,11 @@ describe('Using mocks', () => {
                 expect(commonInstance.publicMethod1('whatever')).toBe(999);
                 expect(commonInstance.publicMethod1('whatever')).toBe(999);
 
-                (commonInstance._spy as any).protectedMethod1._func.and.returnValue(999);
+                commonInstance._spy.protectedMethod1._func.and.returnValue(999);
                 expect((commonInstance as any).protectedMethod1('whatever')).toBe(999);
                 expect((commonInstance as any).protectedMethod1('whatever')).toBe(999);
 
-                (commonInstance._spy as any).privateMethod1._func.and.returnValue(999);
+                commonInstance._spy.privateMethod1._func.and.returnValue(999);
                 expect((commonInstance as any).privateMethod1('whatever')).toBe(999);
                 expect((commonInstance as any).privateMethod1('whatever')).toBe(999);
             });
@@ -867,12 +950,12 @@ describe('Using mocks', () => {
                 expect(commonInstance.publicMethod1('whatever')).toBe(999);
 
                 (commonInstance as any).protectedMethod1('whatever');
-                (commonInstance._spy as any).protectedMethod1._func.and.returnValue(999);
+                commonInstance._spy.protectedMethod1._func.and.returnValue(999);
                 expect((commonInstance as any).protectedMethod1('whatever')).toBe(999);
                 expect((commonInstance as any).protectedMethod1('whatever')).toBe(999);
 
                 (commonInstance as any).privateMethod1('whatever');
-                (commonInstance._spy as any).privateMethod1._func.and.returnValue(999);
+                commonInstance._spy.privateMethod1._func.and.returnValue(999);
                 expect((commonInstance as any).privateMethod1('whatever')).toBe(999);
                 expect((commonInstance as any).privateMethod1('whatever')).toBe(999);
             });
@@ -909,10 +992,10 @@ describe('Using mocks', () => {
                 expect(commonInstance._spy.publicMethod1._func).not.toHaveBeenCalled();
                 expect(() => commonInstance.publicMethod1 = jasmine.createSpy('newSpy')).toThrowError();
 
-                expect((commonInstance._spy as any).protectedMethod1._func).not.toHaveBeenCalled();
+                expect(commonInstance._spy.protectedMethod1._func).not.toHaveBeenCalled();
                 expect(() => (commonInstance as any).privateMethod1 = jasmine.createSpy('newSpy')).toThrowError();
 
-                expect((commonInstance._spy as any).privateMethod1._func).not.toHaveBeenCalled();
+                expect(commonInstance._spy.privateMethod1._func).not.toHaveBeenCalled();
                 expect(() => (commonInstance as any).privateMethod1 = jasmine.createSpy('newSpy')).toThrowError();
             });
 
@@ -920,33 +1003,33 @@ describe('Using mocks', () => {
                 expect(commonInstance._spy.publicMethod1._func).not.toHaveBeenCalled();
                 expect(() => commonInstance._spy.publicMethod1 = {}).toThrowError();
 
-                expect((commonInstance._spy as any).protectedMethod1._func).not.toHaveBeenCalled();
-                expect(() => (commonInstance as any)._spy.privateMethod1 = {}).toThrowError();
+                expect(commonInstance._spy.protectedMethod1._func).not.toHaveBeenCalled();
+                expect(() => commonInstance._spy.privateMethod1 = {}).toThrowError();
 
-                expect((commonInstance._spy as any).privateMethod1._func).not.toHaveBeenCalled();
-                expect(() => (commonInstance as any)._spy.privateMethod1 = {}).toThrowError();
+                expect(commonInstance._spy.privateMethod1._func).not.toHaveBeenCalled();
+                expect(() => commonInstance._spy.privateMethod1 = {}).toThrowError();
             });
 
             it('should not allow reading _get/_set on functions', () => {
                 expect(() => commonInstance._spy.publicMethod1._get).toThrow();
                 expect(() => commonInstance._spy.publicMethod1._set).toThrow();
 
-                expect(() => commonInstance._spy['protectedMethod1']._get).toThrow();
-                expect(() => commonInstance._spy['protectedMethod1']._set).toThrow();
+                expect(() => commonInstance._spy.protectedMethod1._get).toThrow();
+                expect(() => commonInstance._spy.protectedMethod1._set).toThrow();
 
-                expect(() => commonInstance._spy['privateMethod1']._get).toThrow();
-                expect(() => commonInstance._spy['privateMethod1']._set).toThrow();
+                expect(() => commonInstance._spy.privateMethod1._get).toThrow();
+                expect(() => commonInstance._spy.privateMethod1._set).toThrow();
             });
 
             it('should not allow writing _get/_set on functions', () => {
                 expect(() => commonInstance._spy.publicMethod1._get = jasmine.createSpy('whatever')).toThrow();
                 expect(() => commonInstance._spy.publicMethod1._set = jasmine.createSpy('whatever')).toThrow();
 
-                expect(() => commonInstance._spy['protectedMethod1']._get = jasmine.createSpy('whatever')).toThrow();
-                expect(() => commonInstance._spy['protectedMethod1']._set = jasmine.createSpy('whatever')).toThrow();
+                expect(() => commonInstance._spy.protectedMethod1._get = jasmine.createSpy('whatever')).toThrow();
+                expect(() => commonInstance._spy.protectedMethod1._set = jasmine.createSpy('whatever')).toThrow();
 
-                expect(() => commonInstance._spy['privateMethod1']._get = jasmine.createSpy('whatever')).toThrow();
-                expect(() => commonInstance._spy['privateMethod1']._set = jasmine.createSpy('whatever')).toThrow();
+                expect(() => commonInstance._spy.privateMethod1._get = jasmine.createSpy('whatever')).toThrow();
+                expect(() => commonInstance._spy.privateMethod1._set = jasmine.createSpy('whatever')).toThrow();
             });
         });
     }

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,11 +1,15 @@
 export declare type Mock<T> = T & SpyFacade<T>;
 
 export interface SpyFacade<T> {
-    _spy: Spied<T>;
+    _spy: Spied<T> & SpiedAny;
 }
 
 export declare type Spied<T> = {
     [K in keyof T]: SpiedMember;
+}
+
+export interface SpiedAny {
+    [id: string]: SpiedMember
 }
 
 export interface SpiedMember {
@@ -85,11 +89,11 @@ class DynamicBase<T extends object> {
                 Object.defineProperty(this.stub, propertyName, descriptor);
 
                 // by default, let getter spy return whatever setter spy receives
-                const getterSpy = spyOnProperty(this.stub, propertyName, 'get');
-                const setterSpy = spyOnProperty(this.stub, propertyName, 'set');
-                setterSpy.and.callFake((value) => getterSpy.and.returnValue(value));
+                const getterSpy = spyOnProperty(this.stub, propertyName, 'get').and.callFake(() => this.spy[propertyName]._value);
+                const setterSpy = spyOnProperty(this.stub, propertyName, 'set').and.callFake(value => this.spy[propertyName]._value = value);
 
                 this.spy[propertyName] = {
+                    _value: undefined, // this is not on the public API, because _value will become meaningless once user customizes the spies.
                     _get: getterSpy,
                     _set: setterSpy,
                 }

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -76,8 +76,8 @@ class DynamicBase<T extends object> {
             if (typeof this.prototype[propertyName] !== 'function') {
                 // we add getters and setters to all properties to make the read and write spy-able
                 const descriptor = {
-                    get: () => {},
-                    set: (value) => {},
+                    get: /* istanbul ignore next: Can't reach. spyOnProperty() requires its presence to install spies */ () => {},
+                    set: /* istanbul ignore next: Can't reach. spyOnProperty() requires its presence to install spies */ (value) => {},
                     enumerable: true,
                     configurable: true, // required by spyOnProperty
                 };

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,3 +1,19 @@
+export declare type Mock<T> = T & SpyFacade<T>;
+
+export interface SpyFacade<T> {
+    _getSpy(propertyName: keyof T): SpiedMember;
+}
+
+export declare type Spied<T> = {
+    [K in keyof T]: SpiedMember;
+}
+
+export interface SpiedMember {
+    _func: jasmine.Spy;
+    _get: jasmine.Spy;
+    _set: jasmine.Spy;
+}
+
 interface Type<T> extends Function {
     new (...args: any[]): T;
 }
@@ -11,42 +27,106 @@ interface ValueMap {
 }
 
 class DynamicMockBase<T extends object> {
+    public spyFacade = Object.create(null);
+    private stub = Object.create(null);
+
     private spyMap: SpyMap = Object.create(null);
     private valueMap: ValueMap = Object.create(null);
     public handler = {
         get: (target: T, propertyName: keyof T, receiver) => {
-                // trying to get a property, return value from valueMap.
-                if (typeof this.prototype[propertyName] !== 'function') {
-                    return this.valueMap[propertyName];
-                }
 
-                // trying to get a function, if we haven't created the spy, create one
-                if (!this.spyMap[propertyName]) {
-                    const spy = jasmine.createSpy(propertyName);
-                    this.spyMap[propertyName] = spy;
-                }
+            if (propertyName === '_getSpy') {
+                return (propertyNameParam) => this.getSpy(propertyNameParam);
+            }
 
-                return this.spyMap[propertyName];
+            this.initSpy(propertyName);
+
+
+            return this.stub[propertyName];
         },
         // store whatever user wants in the value map
         set: (target, propertyName: keyof T, value, receiver) => {
-            if (typeof this.prototype[propertyName] === 'function') {
-                throw Error(`Assignment not allowed because ${propertyName} is already a spied function`);
+
+            if (propertyName === '_getSpy') {
+                throw Error('Cannot modify _getSpy. It is part of the MockFactory');
             }
 
-            this.valueMap[propertyName] = value;
+            this.initSpy(propertyName);
+
+            this.stub[propertyName] = value;
+
             return true;
         },
     };
 
     constructor(private prototype: T) {}
+
+    public getSpy(propertyName: keyof T): SpiedMember {
+        this.initSpy(propertyName);
+
+        return this.spyFacade[propertyName];
+    }
+
+    private initSpy(propertyName: keyof T): void {
+        // create spy if needed
+        if (!this.spyFacade[propertyName]) {
+            // if target is property
+            if (typeof this.prototype[propertyName] !== 'function') {
+                // TODO __lookupGetter__ and __lookupSetter will be deprecated but Object.getPropertyDesriptor has not arrived.
+                // Consider using polyfill to be future proof
+                const hasGetter = !!(this.prototype as any).__lookupGetter__(propertyName); // this will lookup inherited getter/setter
+                const hasSetter = !!(this.prototype as any).__lookupSetter__(propertyName);
+                let descriptor = Object.getOwnPropertyDescriptor(this.prototype, propertyName); // this will return undefined on inherited getter/setter
+                if (!descriptor) {
+                    descriptor = {
+                        value: undefined,
+                        writable: true,
+                        enumerable: true,
+                        configurable: true,
+                    };
+                } else {
+                    descriptor.value = undefined;
+                }
+
+                if (hasGetter) {
+                    descriptor.get = () => {};
+                    delete descriptor.value;
+                    delete descriptor.writable;
+                }
+
+                if (hasSetter) {
+                    descriptor.set = (...arg) => {};
+                    delete descriptor.value;
+                    delete descriptor.writable;
+                }
+
+                Object.defineProperty(this.stub, propertyName, descriptor);
+
+                this.spyFacade[propertyName] = {
+                    _func: undefined,
+                    _value: undefined,
+                    _get: hasGetter || (descriptor && descriptor.get) ? spyOnProperty(this.stub, propertyName, 'get') : undefined,
+                    _set: hasSetter || (descriptor && descriptor.set) ? spyOnProperty(this.stub, propertyName, 'set') : undefined,
+                }
+            // if target is function
+            } else {
+                const spy = jasmine.createSpy(propertyName);
+                this.stub[propertyName] = spy;
+                this.spyFacade[propertyName] = {
+                    _func: spy,
+                    _get: undefined,
+                    _set: undefined,
+                };
+            }
+        }
+    }
 }
 
 export class MockFactory {
     /**
      * create a mock object that has the identical interface with the class you passed in
      */
-    public static create<T extends object>(blueprint: Type<T> | T) {
+    public static create<T extends object>(blueprint: Type<T> | T): Mock<T> {
         let prototype: T;
         if (blueprint['prototype']) {
             prototype = blueprint['prototype'];
@@ -55,6 +135,7 @@ export class MockFactory {
         }
 
         const mockBase = new DynamicMockBase(prototype);
-        return new Proxy<T>(mockBase as any as T, mockBase.handler);
+        const proxy = new Proxy<Mock<T>>(mockBase as any as Mock<T>, mockBase.handler);
+        return proxy;
     }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -26,7 +26,7 @@
     "label-position": true,
     "max-line-length": [
       true,
-      200
+      256
     ],
     "member-access": false,
     "member-ordering": [


### PR DESCRIPTION
This should solve #1. To get typing for spies:
```TypeScript
mockClass1Instance._spy.publicMethod._func.and.returnValue(999);
```