### PR TITLE
support --strictNullChecks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.0.2
+ * Support `--strictNullChecks` compile
+
 # 2.0.0
  * Support typing of spies through the `_spy` facade.
  * Allow spying and stubbing value accessors on any property

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jasmine-mock-factory",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "A Jasmine helper for creating mocked classes",
   "license": "MIT",
   "author": "Chuanqi Sun",

--- a/src/lib/index.spec.ts
+++ b/src/lib/index.spec.ts
@@ -745,22 +745,22 @@ describe('Using mocks', () => {
 
 
             it('should not allow spiedMembers to be replaced via spyFacade', () => {
-                expect(() => commonInstance._spy.publicProperty1 = {}).toThrow();
+                expect(() => commonInstance._spy.publicProperty1 = {} as any).toThrow();
                 expect(() => (commonInstance._spy as any).publicGetterProperty1 = {}).toThrow();
-                expect(() => commonInstance._spy.publicSetterProperty1 = {}).toThrow();
-                expect(() => commonInstance._spy.publicGetterSetterProperty1 = {}).toThrow();
+                expect(() => commonInstance._spy.publicSetterProperty1 = {} as any).toThrow();
+                expect(() => commonInstance._spy.publicGetterSetterProperty1 = {} as any).toThrow();
 
-                expect(() => (commonInstance._spy.protectedProperty1 = {})).toThrow();
-                expect(() => (commonInstance._spy.protectedGetterProperty1 = {})).toThrow();
-                expect(() => (commonInstance._spy.protectedSetterProperty1 = {})).toThrow();
-                expect(() => (commonInstance._spy.protectedGetterSetterProperty1 = {})).toThrow();
+                expect(() => (commonInstance._spy.protectedProperty1 = {} as any)).toThrow();
+                expect(() => (commonInstance._spy.protectedGetterProperty1 = {} as any)).toThrow();
+                expect(() => (commonInstance._spy.protectedSetterProperty1 = {} as any)).toThrow();
+                expect(() => (commonInstance._spy.protectedGetterSetterProperty1 = {} as any)).toThrow();
 
-                expect(() => (commonInstance._spy.privateProperty1 = {})).toThrow();
-                expect(() => (commonInstance._spy.privateGetterProperty1 = {})).toThrow();
-                expect(() => (commonInstance._spy.privateSetterProperty1 = {})).toThrow();
-                expect(() => (commonInstance._spy.privateGetterSetterProperty1 = {})).toThrow();
+                expect(() => (commonInstance._spy.privateProperty1 = {} as any)).toThrow();
+                expect(() => (commonInstance._spy.privateGetterProperty1 = {} as any)).toThrow();
+                expect(() => (commonInstance._spy.privateSetterProperty1 = {} as any)).toThrow();
+                expect(() => (commonInstance._spy.privateGetterSetterProperty1 = {} as any)).toThrow();
 
-                expect(() => (commonInstance._spy.nonExistProperty = {})).toThrow();
+                expect(() => (commonInstance._spy.nonExistProperty = {} as any)).toThrow();
             });
 
             it('should not allow reading _func on properties', () => {
@@ -1001,13 +1001,13 @@ describe('Using mocks', () => {
 
             it('should not allow spiedMembers to be replaced via spyFacade', () => {
                 expect(commonInstance._spy.publicMethod1._func).not.toHaveBeenCalled();
-                expect(() => commonInstance._spy.publicMethod1 = {}).toThrowError();
+                expect(() => commonInstance._spy.publicMethod1 = {} as any).toThrowError();
 
                 expect(commonInstance._spy.protectedMethod1._func).not.toHaveBeenCalled();
-                expect(() => commonInstance._spy.privateMethod1 = {}).toThrowError();
+                expect(() => commonInstance._spy.privateMethod1 = {} as any).toThrowError();
 
                 expect(commonInstance._spy.privateMethod1._func).not.toHaveBeenCalled();
-                expect(() => commonInstance._spy.privateMethod1 = {}).toThrowError();
+                expect(() => commonInstance._spy.privateMethod1 = {} as any).toThrowError();
             });
 
             it('should not allow reading _get/_set on functions', () => {

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -13,9 +13,9 @@ export interface SpiedAny {
 }
 
 export interface SpiedMember {
-    _func?: jasmine.Spy;
-    _get?: jasmine.Spy;
-    _set?: jasmine.Spy;
+    _func: jasmine.Spy;
+    _get: jasmine.Spy;
+    _set: jasmine.Spy;
 }
 
 interface Type<T> extends Function {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "moduleResolution": "node",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
+    "strictNullChecks": true,
     "target": "es5",
     "typeRoots": [
       "node_modules/@types"


### PR DESCRIPTION
address #4 by explicitly typing members of `SpiedMember ` as non-nullable